### PR TITLE
Test Order & Concurrency

### DIFF
--- a/.github/workflows/packaging_wheels.yml
+++ b/.github/workflows/packaging_wheels.yml
@@ -57,7 +57,7 @@ jobs:
         uv export --only-group test --no-emit-project --output-file pylock.toml --directory {project} &&
         uv pip install -r pylock.toml
       CIBW_TEST_COMMAND: >
-        uv run -v pytest ${{ inputs.testsuite == 'fast' && './tests/fast' || './tests' }} --verbose --ignore=./tests/stubs
+        uv run -v pytest -n 2 ${{ inputs.testsuite == 'fast' && './tests/fast' || './tests' }} --verbose --ignore=./tests/stubs
 
     steps:
       - name: Checkout DuckDB Python

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,6 +227,8 @@ test = [ # dependencies used for running tests
     "pytest",
     "pytest-reraise",
     "pytest-timeout",
+    "pytest-xdist", #  multi-processed tests, if `-n <num_workers> | auto`
+    "pytest-randomly", # randomizes test order to ensure no test dependencies, enabled on install
     "mypy",
     "coverage",
     "gcovr; python_version < '3.14'",
@@ -306,6 +308,7 @@ filterwarnings = [
     "ignore:distutils Version classes are deprecated:DeprecationWarning",
     "ignore:is_datetime64tz_dtype is deprecated:DeprecationWarning",
 ]
+timeout = 600  # don't let individual tests "hang"
 
 [tool.coverage.run]
 branch = true

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -267,10 +267,18 @@ def spark():
 
 
 @pytest.fixture(scope='function')
-def duckdb_cursor():
-    connection = duckdb.connect('')
-    yield connection
-    connection.close()
+def duckdb_cursor(tmp_path):
+    with duckdb.connect(tmp_path / "mytest") as connection:
+        yield connection
+
+
+@pytest.fixture(scope='function')
+def default_con():
+    # ensures each test uses a fresh default connection to avoid test leakage
+    # threading_unsafe fixture
+    duckdb.default_connection().close()
+    with duckdb.default_connection() as conn:
+        yield conn
 
 
 @pytest.fixture(scope='function')

--- a/tests/fast/api/test_query_interrupt.py
+++ b/tests/fast/api/test_query_interrupt.py
@@ -1,35 +1,31 @@
 import duckdb
 import time
 import pytest
-
 import platform
 import threading
 import _thread as thread
 
 
 def send_keyboard_interrupt():
-    # Wait a little, so we're sure the 'execute' has started
     time.sleep(0.1)
-    # Send an interrupt to the main thread
     thread.interrupt_main()
 
 
 class TestQueryInterruption(object):
+    
     @pytest.mark.xfail(
         condition=platform.system() == "Emscripten",
         reason="Emscripten builds cannot use threads",
     )
-    def test_query_interruption(self):
+    @pytest.mark.timeout(15)
+    def test_keyboard_interruption(self):
         con = duckdb.connect()
         thread = threading.Thread(target=send_keyboard_interrupt)
         # Start the thread
         thread.start()
         try:
-            res = con.execute('select count(*) from range(100000000000)').fetchall()
-        except RuntimeError:
-            # If this is not reached, we could not cancel the query before it completed
-            # indicating that the query interruption functionality is broken
-            assert True
-        except KeyboardInterrupt:
-            pytest.fail()
-        thread.join()
+            with pytest.raises((KeyboardInterrupt, RuntimeError)):
+                res = con.execute('select * from range(100000) t1,range(100000) t2').fetchall()
+        finally:
+            # Ensure the thread completes regardless of what happens
+            thread.join()

--- a/tests/fast/api/test_to_csv.py
+++ b/tests/fast/api/test_to_csv.py
@@ -1,5 +1,4 @@
 import duckdb
-import tempfile
 import os
 import pandas._testing as tm
 import datetime
@@ -10,63 +9,63 @@ from conftest import NumpyPandas, ArrowPandas, getTimeSeriesData
 
 class TestToCSV(object):
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_basic_to_csv(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_basic_to_csv(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': [5, 3, 23, 2], 'b': [45, 234, 234, 2]})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
 
         rel.to_csv(temp_file_name)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = default_con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_sep(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_sep(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': [5, 3, 23, 2], 'b': [45, 234, 234, 2]})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
 
         rel.to_csv(temp_file_name, sep=',')
 
-        csv_rel = duckdb.read_csv(temp_file_name, sep=',')
+        csv_rel = default_con.read_csv(temp_file_name, sep=',')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_na_rep(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_na_rep(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': [5, None, 23, 2], 'b': [45, 234, 234, 2]})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
 
         rel.to_csv(temp_file_name, na_rep="test")
 
-        csv_rel = duckdb.read_csv(temp_file_name, na_values="test")
+        csv_rel = default_con.read_csv(temp_file_name, na_values="test")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_header(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_header(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': [5, None, 23, 2], 'b': [45, 234, 234, 2]})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
 
         rel.to_csv(temp_file_name)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = default_con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quotechar(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quotechar(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': ["\'a,b,c\'", None, "hello", "bye"], 'b': [45, 234, 234, 2]})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
 
         rel.to_csv(temp_file_name, quotechar='\'', sep=',')
 
-        csv_rel = duckdb.read_csv(temp_file_name, sep=',', quotechar='\'')
+        csv_rel = default_con.read_csv(temp_file_name, sep=',', quotechar='\'')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_escapechar(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_escapechar(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame(
             {
                 "c_bool": [True, False],
@@ -75,97 +74,102 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, quotechar='"', escapechar='!')
-        csv_rel = duckdb.read_csv(temp_file_name, quotechar='"', escapechar='!')
+        csv_rel = default_con.read_csv(temp_file_name, quotechar='"', escapechar='!')
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_date_format(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_date_format(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame(getTimeSeriesData())
         dt_index = df.index
         df = pandas.DataFrame({"A": dt_index, "B": dt_index.shift(1)}, index=dt_index)
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, date_format="%Y%m%d")
 
-        csv_rel = duckdb.read_csv(temp_file_name, date_format="%Y%m%d")
+        csv_rel = default_con.read_csv(temp_file_name, date_format="%Y%m%d")
 
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_timestamp_format(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_timestamp_format(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         data = [datetime.time(hour=23, minute=1, second=34, microsecond=234345)]
         df = pandas.DataFrame({'0': pandas.Series(data=data, dtype='object')})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, timestamp_format='%m/%d/%Y')
 
-        csv_rel = duckdb.read_csv(temp_file_name, timestamp_format='%m/%d/%Y')
+        csv_rel = default_con.read_csv(temp_file_name, timestamp_format='%m/%d/%Y')
 
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_off(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quoting_off(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, quoting=None)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = default_con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_on(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quoting_on(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, quoting="force")
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = default_con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_quoting_quote_all(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_quoting_quote_all(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, quoting=csv.QUOTE_ALL)
 
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = default_con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_encoding_incorrect(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_encoding_incorrect(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         with pytest.raises(
             duckdb.InvalidInputException, match="Invalid Input Error: The only supported encoding option is 'UTF8"
         ):
             rel.to_csv(temp_file_name, encoding="nope")
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_encoding_correct(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_encoding_correct(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, encoding="UTF-8")
-        csv_rel = duckdb.read_csv(temp_file_name)
+        csv_rel = default_con.read_csv(temp_file_name)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_compression_gzip(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_compression_gzip(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame({'a': ['string1', 'string2', 'string3']})
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, compression="gzip")
-        csv_rel = duckdb.read_csv(temp_file_name, compression="gzip")
+        csv_rel = default_con.read_csv(temp_file_name, compression="gzip")
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_partition(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_partition(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame(
             {
                 "c_category": ['a', 'a', 'b', 'b'],
@@ -175,9 +179,9 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, header=True, partition_by=["c_category"])
-        csv_rel = duckdb.sql(
+        csv_rel = default_con.sql(
             f'''FROM read_csv_auto('{temp_file_name}/*/*.csv', hive_partitioning=TRUE, header=TRUE);'''
         )
         expected = [
@@ -190,8 +194,9 @@ class TestToCSV(object):
         assert csv_rel.execute().fetchall() == expected
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_partition_with_columns_written(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_partition_with_columns_written(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame(
             {
                 "c_category": ['a', 'a', 'b', 'b'],
@@ -201,17 +206,18 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
-        res = duckdb.sql("FROM rel order by all")
+        rel = default_con.from_df(df)
+        res = default_con.sql("FROM rel order by all")
         rel.to_csv(temp_file_name, header=True, partition_by=["c_category"], write_partition_columns=True)
-        csv_rel = duckdb.sql(
+        csv_rel = default_con.sql(
             f'''FROM read_csv_auto('{temp_file_name}/*/*.csv', hive_partitioning=TRUE, header=TRUE) order by all;'''
         )
         assert res.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_overwrite(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -222,10 +228,10 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])  # csv to be overwritten
         rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"], overwrite=True)
-        csv_rel = duckdb.sql(
+        csv_rel = default_con.sql(
             f'''FROM read_csv_auto('{temp_file_name}/*/*.csv', hive_partitioning=TRUE, header=TRUE);'''
         )
         # When partition columns are read from directory names, column order become different from original
@@ -238,8 +244,9 @@ class TestToCSV(object):
         assert csv_rel.execute().fetchall() == expected
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite_with_columns_written(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_overwrite_with_columns_written(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -250,22 +257,23 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(
             temp_file_name, header=True, partition_by=["c_category_1"], write_partition_columns=True
         )  # csv to be overwritten
         rel.to_csv(
             temp_file_name, header=True, partition_by=["c_category_1"], overwrite=True, write_partition_columns=True
         )
-        csv_rel = duckdb.sql(
+        csv_rel = default_con.sql(
             f'''FROM read_csv_auto('{temp_file_name}/*/*.csv', hive_partitioning=TRUE, header=TRUE) order by all;'''
         )
-        res = duckdb.sql("FROM rel order by all")
+        res = default_con.sql("FROM rel order by all")
         assert res.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_overwrite_not_enabled(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_overwrite_not_enabled(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -276,15 +284,16 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])
         with pytest.raises(duckdb.IOException, match="OVERWRITE"):
             rel.to_csv(temp_file_name, header=True, partition_by=["c_category_1"])
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_per_thread_output(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
-        num_threads = duckdb.sql("select current_setting('threads')").fetchone()[0]
+    def test_to_csv_per_thread_output(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
+        num_threads = default_con.sql("select current_setting('threads')").fetchone()[0]
         print('num_threads:', num_threads)
         df = pandas.DataFrame(
             {
@@ -295,14 +304,15 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, header=True, per_thread_output=True)
-        csv_rel = duckdb.read_csv(f'{temp_file_name}/*.csv', header=True)
+        csv_rel = default_con.read_csv(f'{temp_file_name}/*.csv', header=True)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()
 
     @pytest.mark.parametrize('pandas', [NumpyPandas(), ArrowPandas()])
-    def test_to_csv_use_tmp_file(self, pandas):
-        temp_file_name = os.path.join(tempfile.mkdtemp(), next(tempfile._get_candidate_names()))
+    def test_to_csv_use_tmp_file(self, pandas, tmp_path, default_con):
+        temp_file_name = str(tmp_path / "test.csv")
+
         df = pandas.DataFrame(
             {
                 "c_category_1": ['a', 'a', 'b', 'b'],
@@ -313,8 +323,8 @@ class TestToCSV(object):
                 "c_string": ["a", "b,c", "e", "f"],
             }
         )
-        rel = duckdb.from_df(df)
+        rel = default_con.from_df(df)
         rel.to_csv(temp_file_name, header=True)  # csv to be overwritten
         rel.to_csv(temp_file_name, header=True, use_tmp_file=True)
-        csv_rel = duckdb.read_csv(temp_file_name, header=True)
+        csv_rel = default_con.read_csv(temp_file_name, header=True)
         assert rel.execute().fetchall() == csv_rel.execute().fetchall()

--- a/tests/fast/test_many_con_same_file.py
+++ b/tests/fast/test_many_con_same_file.py
@@ -10,28 +10,19 @@ def get_tables(con):
     return tbls
 
 
-def test_multiple_writes():
-    try:
-        os.remove("test.db")
-    except:
-        pass
-    con1 = duckdb.connect("test.db")
-    con2 = duckdb.connect("test.db")
+def test_multiple_writes(tmp_path):
+    con1 = duckdb.connect(tmp_path / "test.db")
+    con2 = duckdb.connect(tmp_path / "test.db")
     con1.execute("CREATE TABLE foo1 as SELECT 1 as a, 2 as b")
     con2.execute("CREATE TABLE bar1 as SELECT 2 as a, 3 as b")
     con2.close()
     con1.close()
-    con3 = duckdb.connect("test.db")
+    con3 = duckdb.connect(tmp_path / "test.db")
     tbls = get_tables(con3)
     assert tbls == ['bar1', 'foo1']
     del con1
     del con2
     del con3
-
-    try:
-        os.remove("test.db")
-    except:
-        pass
 
 
 def test_multiple_writes_memory():
@@ -64,23 +55,23 @@ def test_multiple_writes_named_memory():
     del con3
 
 
-def test_diff_config():
-    con1 = duckdb.connect("test.db", False)
+def test_diff_config(tmp_path):
+    con1 = duckdb.connect(tmp_path / "test.db", False)
     with pytest.raises(
         duckdb.ConnectionException,
         match="Can't open a connection to same database file with a different configuration than existing connections",
     ):
-        con2 = duckdb.connect("test.db", True)
+        con2 = duckdb.connect(tmp_path / "test.db", True)
     con1.close()
     del con1
 
 
-def test_diff_config_extended():
-    con1 = duckdb.connect("test.db", config={'null_order': 'NULLS FIRST'})
+def test_diff_config_extended(tmp_path):
+    con1 = duckdb.connect(tmp_path / "test.db", config={'null_order': 'NULLS FIRST'})
     with pytest.raises(
         duckdb.ConnectionException,
         match="Can't open a connection to same database file with a different configuration than existing connections",
     ):
-        con2 = duckdb.connect("test.db")
+        con2 = duckdb.connect(tmp_path / "test.db")
     con1.close()
     del con1

--- a/tests/fast/test_relation.py
+++ b/tests/fast/test_relation.py
@@ -1,6 +1,5 @@
 import duckdb
 import numpy as np
-import platform
 import tempfile
 import os
 import pandas as pd
@@ -527,13 +526,6 @@ class TestRelation(object):
             2048,
             5000,
             1000000,
-            pytest.param(
-                10000000,
-                marks=pytest.mark.skipif(
-                    condition=platform.system() == "Emscripten",
-                    reason="Emscripten/Pyodide builds run out of memory at this scale, and error might not thrown reliably",
-                ),
-            ),
         ],
     )
     def test_materialized_relation(self, duckdb_cursor, num_rows):

--- a/tests/slow/test_relation_slow.py
+++ b/tests/slow/test_relation_slow.py
@@ -1,0 +1,20 @@
+import platform
+import pytest
+
+
+class TestRelationSlow(object):
+    @pytest.mark.skipif(
+        condition=platform.system() == "Emscripten",
+        reason="Emscripten/Pyodide builds run out of memory at this scale, and error might not thrown reliably",
+    )
+    def test_materialized_relation_large(self, duckdb_cursor):
+        """Test materialized relation with 10M rows - moved from fast tests due to 1+ minute runtime"""
+        # Import the implementation function from the fast test
+        import sys
+        import os
+        sys.path.append(os.path.join(os.path.dirname(__file__), '..', 'fast'))
+        from test_relation import TestRelation
+
+        # Create instance and call the test with large parameter
+        test_instance = TestRelation()
+        test_instance.test_materialized_relation(duckdb_cursor, 10000000)


### PR DESCRIPTION
This arose from [discussion](https://github.com/duckdb/duckdb-python/discussions/40)

While running tests for free-threading, I found some test "contamination": tests that are order-dependent or lack isolation of resources. 

\* This PR makes no functional changes, only changes to tests / testing.

This PR addresses the individual tests and adds steps to detect in the future: 
- Randomizing their order: to surface any order dependencies
- Enabling multi-process parallelism to tests, identifying any dependencies and also reducing overall test time
- Using unique path fixtures or table names to eliminate conflicts across concurrent tests
- Moved a slow test (10M rows) to tests/slow
- Reworked test_query_interruption. 
- added a 10 minute timeout for pytests

#### Added Plugins

##### [pytest-xdist](https://pytest-xdist.readthedocs.io/en/stable/)
Disabled by default. This PR adds `-n 2` to packaging_wheels to run two parallel tests at a time. 

Comments: 
- One concern would be overloading the test runners. I haven't found this to happen: `-n auto` was surprisingly fine. I believe Runners on public repos are 4 cores.
- I suggest `-n 2` as a first step in case any issues with the more performance intensive tests. 
- When doing performance testing, don't pass `-n`. 

##### [pytest-randomly](https://github.com/pytest-dev/pytest-randomly)
Enabled by default. Randomizes the order of tests. 

Comments:
- Random order is good for surfacing test dependencies and assumptions
- This identified a number of test dependencies, especially around use of a "dirty" default connection or reusing file names