### PR TITLE
3.14: Bump to rc3 and add Windows build

### DIFF
--- a/.github/workflows/cleanup_pypi.yml
+++ b/.github/workflows/cleanup_pypi.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Install Astral UV
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.16"
+          version: "0.8.22"
 
       - name: Run Cleanup
         env:

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Install Astral UV and enable the cache
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.16"
+          version: "0.8.22"
           python-version: 3.9
           enable-cache: true
           cache-suffix: -${{ github.workflow }}

--- a/.github/workflows/packaging_sdist.yml
+++ b/.github/workflows/packaging_sdist.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Astral UV
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.16"
+          version: "0.8.22"
           python-version: 3.11
 
       - name: Build sdist

--- a/.github/workflows/packaging_wheels.yml
+++ b/.github/workflows/packaging_wheels.yml
@@ -45,9 +45,6 @@ jobs:
           - { minimal: true, python: cp311 }
           - { minimal: true, python: cp312 }
           - { minimal: true, platform: { arch: universal2 } }
-          # Windows+cp314t disabled due to test failures in CI. 
-          # TODO: Diagnose why tests fail (access violations) in some configurations
-          - { python: cp314t, platform: { os: windows-2025 } }  
 
     runs-on: ${{ matrix.platform.os }}
     env:

--- a/.github/workflows/packaging_wheels.yml
+++ b/.github/workflows/packaging_wheels.yml
@@ -84,13 +84,13 @@ jobs:
       # Install Astral UV, which will be used as build-frontend for cibuildwheel
       - uses: astral-sh/setup-uv@v6
         with:
-          version: "0.8.16"
+          version: "0.8.22"
           enable-cache: false
           cache-suffix: -${{ matrix.python }}-${{ matrix.platform.cibw_system }}_${{ matrix.platform.arch }}
           python-version: ${{ matrix.python }}
 
       - name: Build${{ inputs.testsuite != 'none' && ' and test ' || ' ' }}wheels
-        uses: pypa/cibuildwheel@v3.1
+        uses: pypa/cibuildwheel@v3.2
         env:
           CIBW_ARCHS: ${{ matrix.platform.arch == 'amd64' && 'AMD64' || matrix.platform.arch }}
           CIBW_BUILD: ${{ matrix.python }}-${{ matrix.platform.cibw_system }}_${{ matrix.platform.arch }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,6 +123,15 @@ if.env.COVERAGE = false
 inherit.cmake.define = "append"
 cmake.define.DISABLE_UNITY = "1"
 
+[[tool.scikit-build.overrides]]
+if.platform-system = "^win32"
+if.abi-flags = "t"
+inherit.cmake.define = "append"
+# /DPy_GIL_DISABLED: needed else the build will try to link python314.lib
+# CMAKE_..._FLAGS_INIT not FLAGS: otherwise, msbuild will disable important defaults such as /EHsc
+cmake.define.CMAKE_C_FLAGS_INIT="/DPy_MOD_GIL_USED /DPy_GIL_DISABLED"
+cmake.define.CMAKE_CXX_FLAGS_INIT="/DPy_MOD_GIL_USED /DPy_GIL_DISABLED"
+
 [tool.scikit-build.sdist]
 include = [
     "README.md",


### PR DESCRIPTION
This is a follow-up to https://github.com/duckdb/duckdb-python/pull/50, which added 3.14 & 3.14t builds. These builds targeted rc2. 

[3.14.0rc3](https://www.python.org/downloads/release/python-3140rc3/) is now released, and is available in [uv 0.8.19](https://github.com/astral-sh/uv/releases/tag/0.8.19) and [cibuildwheel 3.2](https://github.com/pypa/cibuildwheel/releases/tag/v3.2.0). 

This PR:
- Bumps uv and cibuildwheel to support 3.14 rc3
- Adds the Windows 3.14t build

\* The Windows issue in prior PR was CMAKE_CXX_FLAGS_INIT vs CMAKE_CXX_FLAGS. The latter modifies defaults.