### PR TITLE
Python Table Valued Functions / User Defined Table Functions

### DIFF
--- a/duckdb/functional/__init__.py
+++ b/duckdb/functional/__init__.py
@@ -1,17 +1,23 @@
 from _duckdb.functional import (
 	FunctionNullHandling,
 	PythonUDFType,
+	PythonTVFType,
 	SPECIAL,
 	DEFAULT,
 	NATIVE,
-	ARROW
+	ARROW,
+	TUPLES,
+	ARROW_TABLE
 )
 
 __all__ = [
 	"FunctionNullHandling",
 	"PythonUDFType",
+	"PythonTVFType",
 	"SPECIAL",
 	"DEFAULT",
 	"NATIVE",
-	"ARROW"
+	"ARROW",
+	"TUPLES",
+	"ARROW_TABLE"
 ]

--- a/scripts/connection_methods.json
+++ b/scripts/connection_methods.json
@@ -108,6 +108,51 @@
 		"return": "DuckDBPyConnection"
 	},
 	{
+		"name": "create_table_function",
+		"function": "RegisterTableFunction",
+		"docs": "Register a table valued function via Callable",
+		"args": [
+			{
+				"name": "name",
+				"type": "str"
+			},
+			{
+				"name": "callable",
+				"type": "Callable"
+			}
+		],
+		"kwargs": [
+			{
+				"name": "parameters",
+				"type": "Optional[Any]",
+				"default": "None"
+			},
+			{
+				"name": "schema",
+				"type": "Optional[Any]",
+				"default": "None"
+			},
+			{
+				"name": "type",
+				"type": "Optional[PythonTVFType]",
+				"default": "PythonTVFType.TUPLES"
+			}
+		],
+		"return": "DuckDBPyConnection"
+	},
+	{
+		"name": "unregister_table_function",
+		"function": "UnregisterTableFunction",
+		"docs": "Unregister a table valued function",
+		"args": [
+			{
+				"name": "name",
+				"type": "str"
+			}
+		],
+		"return": "DuckDBPyConnection"
+	},
+	{
 		"name": [
 			"sqltype",
 			"dtype",

--- a/src/duckdb_py/CMakeLists.txt
+++ b/src/duckdb_py/CMakeLists.txt
@@ -28,6 +28,7 @@ add_library(python_src OBJECT
         python_import_cache.cpp
         python_replacement_scan.cpp
         python_udf.cpp
+        python_tvf.cpp
 )
 
 target_link_libraries(python_src PRIVATE _duckdb_dependencies)

--- a/src/duckdb_py/functional/functional.cpp
+++ b/src/duckdb_py/functional/functional.cpp
@@ -11,6 +11,11 @@ void DuckDBPyFunctional::Initialize(py::module_ &parent) {
 	    .value("ARROW", duckdb::PythonUDFType::ARROW)
 	    .export_values();
 
+	py::enum_<duckdb::PythonTVFType>(m, "PythonTVFType")
+	    .value("TUPLES", duckdb::PythonTVFType::TUPLES)
+	    .value("ARROW_TABLE", duckdb::PythonTVFType::ARROW_TABLE)
+	    .export_values();
+
 	py::enum_<duckdb::FunctionNullHandling>(m, "FunctionNullHandling")
 	    .value("DEFAULT", duckdb::FunctionNullHandling::DEFAULT_NULL_HANDLING)
 	    .value("SPECIAL", duckdb::FunctionNullHandling::SPECIAL_HANDLING)

--- a/src/duckdb_py/include/duckdb_python/pybind11/conversions/python_tvf_type_enum.hpp
+++ b/src/duckdb_py/include/duckdb_python/pybind11/conversions/python_tvf_type_enum.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include "duckdb/common/common.hpp"
+#include "duckdb/common/exception.hpp"
+#include "duckdb/common/string_util.hpp"
+
+using duckdb::InvalidInputException;
+using duckdb::string;
+using duckdb::StringUtil;
+
+namespace duckdb {
+
+enum class PythonTVFType : uint8_t { TUPLES, ARROW_TABLE };
+
+} // namespace duckdb
+
+using duckdb::PythonTVFType;
+
+namespace py = pybind11;
+
+static PythonTVFType PythonTVFTypeFromString(const string &type) {
+	auto ltype = StringUtil::Lower(type);
+	if (ltype.empty() || ltype == "tuples") {
+		return PythonTVFType::TUPLES;
+	} else if (ltype == "arrow_table") {
+		return PythonTVFType::ARROW_TABLE;
+	} else {
+		throw InvalidInputException("'%s' is not a recognized type for 'tvf_type'", type);
+	}
+}
+
+static PythonTVFType PythonTVFTypeFromInteger(int64_t value) {
+	if (value == 0) {
+		return PythonTVFType::TUPLES;
+	} else if (value == 1) {
+		return PythonTVFType::ARROW_TABLE;
+	} else {
+		throw InvalidInputException("'%d' is not a recognized type for 'tvf_type'", value);
+	}
+}
+
+namespace PYBIND11_NAMESPACE {
+namespace detail {
+
+template <>
+struct type_caster<PythonTVFType> : public type_caster_base<PythonTVFType> {
+	using base = type_caster_base<PythonTVFType>;
+	PythonTVFType tmp;
+
+public:
+	bool load(handle src, bool convert) {
+		if (base::load(src, convert)) {
+			return true;
+		} else if (py::isinstance<py::str>(src)) {
+			tmp = PythonTVFTypeFromString(py::str(src));
+			value = &tmp;
+			return true;
+		} else if (py::isinstance<py::int_>(src)) {
+			tmp = PythonTVFTypeFromInteger(src.cast<int64_t>());
+			value = &tmp;
+			return true;
+		}
+		return false;
+	}
+
+	static handle cast(PythonTVFType src, return_value_policy policy, handle parent) {
+		return base::cast(src, policy, parent);
+	}
+};
+
+} // namespace detail
+} // namespace PYBIND11_NAMESPACE

--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -393,12 +393,62 @@ DuckDBPyConnection::RegisterScalarUDF(const string &name, const py::function &ud
 	auto scalar_function = CreateScalarUDF(name, udf, parameters_p, return_type_p, type == PythonUDFType::ARROW,
 	                                       null_handling, exception_handling, side_effects);
 	CreateScalarFunctionInfo info(scalar_function);
-
 	context.RegisterFunction(info);
 
 	auto dependency = make_uniq<ExternalDependency>();
 	dependency->AddDependency("function", PythonDependencyItem::Create(udf));
 	registered_functions[name] = std::move(dependency);
+
+	return shared_from_this();
+}
+
+shared_ptr<DuckDBPyConnection> DuckDBPyConnection::RegisterTableFunction(const string &name,
+                                                                         const py::function &function,
+                                                                         const py::object &parameters,
+                                                                         const py::object &schema,
+                                                                         PythonTVFType type) {
+
+	auto &connection = con.GetConnection();
+	auto &context = *connection.context;
+
+	if (context.transaction.HasActiveTransaction()) {
+		context.CancelTransaction();
+	}
+
+	if (registered_table_functions.find(name) != registered_table_functions.end()) {
+		throw NotImplementedException("A table function by the name of '%s' is already registered, "
+		                              "please unregister it first",
+		                              name);
+	}
+
+	auto table_function = CreateTableFunctionFromCallable(name, function, parameters, schema, type);
+	CreateTableFunctionInfo info(table_function);
+
+	// re-registration: changing the callable to another
+	info.on_conflict = OnCreateConflict::REPLACE_ON_CONFLICT;
+
+	context.RegisterFunction(info);
+
+	auto dependency = make_uniq<ExternalDependency>();
+	dependency->AddDependency("function", PythonDependencyItem::Create(function));
+	registered_table_functions[name] = std::move(dependency);
+
+	return shared_from_this();
+}
+
+shared_ptr<DuckDBPyConnection> DuckDBPyConnection::UnregisterTableFunction(const string &name) {
+	auto entry = registered_table_functions.find(name);
+	if (entry == registered_table_functions.end()) {
+		throw InvalidInputException(
+		    "No table function by the name of '%s' was found in the list of registered table functions", name);
+	}
+
+	auto &connection = con.GetConnection();
+	auto &context = *connection.context;
+
+	// Remove from our registry.
+	// TODO: Callable still exists in the function catalog, since duckdb doesn't (yet?) support removal
+	registered_table_functions.erase(entry);
 
 	return shared_from_this();
 }
@@ -410,6 +460,14 @@ void DuckDBPyConnection::Initialize(py::handle &m) {
 	connection_module.def("__enter__", &DuckDBPyConnection::Enter)
 	    .def("__exit__", &DuckDBPyConnection::Exit, py::arg("exc_type"), py::arg("exc"), py::arg("traceback"));
 	connection_module.def("__del__", &DuckDBPyConnection::Close);
+
+	connection_module.def("create_table_function", &DuckDBPyConnection::RegisterTableFunction,
+	                      "Register a table valued function via Callable", py::arg("name"), py::arg("callable"),
+	                      py::arg("parameters") = py::none(), py::arg("schema") = py::none(),
+	                      py::arg("type") = PythonTVFType::TUPLES);
+
+	connection_module.def("unregister_table_function", &DuckDBPyConnection::UnregisterTableFunction,
+	                      "Unregister a table valued function", py::arg("name"));
 
 	InitializeConnectionMethods(connection_module);
 	connection_module.def_property_readonly("description", &DuckDBPyConnection::GetDescription,
@@ -1575,7 +1633,12 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const py::object &quer
 		}
 		if (res->type == QueryResultType::STREAM_RESULT) {
 			auto &stream_result = res->Cast<StreamQueryResult>();
-			res = stream_result.Materialize();
+			{
+				// Release the GIL, as Materialize *may* need the GIL (TVFs, for instance)
+				D_ASSERT(py::gil_check());
+				py::gil_scoped_release release;
+				res = stream_result.Materialize();
+			}
 		}
 		auto &materialized_result = res->Cast<MaterializedQueryResult>();
 		relation = make_shared_ptr<MaterializedRelation>(connection.context, materialized_result.TakeCollection(),
@@ -1826,6 +1889,7 @@ void DuckDBPyConnection::Close() {
 	// https://peps.python.org/pep-0249/#Connection.close
 	cursors.ClearCursors();
 	registered_functions.clear();
+	registered_table_functions.clear();
 }
 
 void DuckDBPyConnection::Interrupt() {

--- a/src/duckdb_py/python_tvf.cpp
+++ b/src/duckdb_py/python_tvf.cpp
@@ -1,0 +1,355 @@
+#include "duckdb_python/pybind11/pybind_wrapper.hpp"
+#include "duckdb_python/pytype.hpp"
+#include "duckdb_python/pyconnection/pyconnection.hpp"
+#include "duckdb/common/arrow/arrow.hpp"
+#include "duckdb/common/arrow/arrow_wrapper.hpp"
+#include "duckdb_python/arrow/arrow_array_stream.hpp"
+#include "duckdb/function/table/arrow.hpp"
+#include "duckdb/function/function.hpp"
+#include "duckdb/parser/tableref/table_function_ref.hpp"
+#include "duckdb_python/python_conversion.hpp"
+#include "duckdb_python/python_objects.hpp"
+#include "duckdb_python/pybind11/python_object_container.hpp"
+
+namespace duckdb {
+
+struct PyTVFInfo : public TableFunctionInfo {
+	py::function callable;
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+	PythonTVFType return_type;
+
+	PyTVFInfo(py::function callable_p, vector<LogicalType> types_p, vector<string> names_p, PythonTVFType return_type_p)
+	    : callable(std::move(callable_p)), return_types(std::move(types_p)), return_names(std::move(names_p)),
+	      return_type(return_type_p) {
+	}
+
+	~PyTVFInfo() override {
+		py::gil_scoped_acquire acquire;
+		callable = py::function();
+	}
+};
+
+struct PyTVFBindData : public TableFunctionData {
+	string func_name;
+	vector<Value> args;
+	named_parameter_map_t kwargs;
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+	PythonObjectContainer python_objects; // Holds the callable
+
+	PyTVFBindData(string func_name, vector<Value> args, named_parameter_map_t kwargs, vector<LogicalType> return_types,
+	              vector<string> return_names, py::function callable)
+	    : func_name(std::move(func_name)), args(std::move(args)), kwargs(std::move(kwargs)),
+	      return_types(std::move(return_types)), return_names(std::move(return_names)) {
+		// gil acquired inside push
+		python_objects.Push(std::move(callable));
+	}
+};
+
+struct PyTVFTuplesGlobalState : public GlobalTableFunctionState {
+	PythonObjectContainer python_objects;
+	bool iterator_exhausted = false;
+
+	PyTVFTuplesGlobalState() : iterator_exhausted(false) {
+	}
+};
+
+struct PyTVFArrowGlobalState : public GlobalTableFunctionState {
+	unique_ptr<PythonTableArrowArrayStreamFactory> arrow_factory;
+	unique_ptr<FunctionData> arrow_bind_data;
+	unique_ptr<GlobalTableFunctionState> arrow_global_state;
+	PythonObjectContainer python_objects;
+	idx_t num_columns;
+
+	PyTVFArrowGlobalState() {
+	}
+};
+
+static void PyTVFTuplesScanFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	auto &gs = input.global_state->Cast<PyTVFTuplesGlobalState>();
+	auto &bd = input.bind_data->Cast<PyTVFBindData>();
+
+	if (gs.iterator_exhausted) {
+		output.SetCardinality(0);
+		return;
+	}
+
+	py::gil_scoped_acquire gil;
+	auto &it = gs.python_objects.LastAddedObject();
+
+	idx_t row_idx = 0;
+	for (idx_t i = 0; i < STANDARD_VECTOR_SIZE; i++) {
+		py::object next_item;
+		try {
+			next_item = it.attr("__next__")();
+		} catch (py::error_already_set &e) {
+			if (e.matches(PyExc_StopIteration)) {
+				gs.iterator_exhausted = true;
+				PyErr_Clear();
+				break;
+			}
+			throw;
+		}
+
+		try {
+			// Extract each column from the tuple/list
+			for (idx_t col_idx = 0; col_idx < bd.return_types.size(); col_idx++) {
+				auto py_val = next_item[py::int_(col_idx)];
+				Value duck_val = TransformPythonValue(py_val, bd.return_types[col_idx]);
+				output.SetValue(col_idx, row_idx, duck_val);
+			}
+		} catch (py::error_already_set &e) {
+			throw InvalidInputException("Table function '%s' returned invalid data: %s", bd.func_name, e.what());
+		}
+		row_idx++;
+	}
+	output.SetCardinality(row_idx);
+}
+
+struct PyTVFArrowLocalState : public LocalTableFunctionState {
+	unique_ptr<LocalTableFunctionState> arrow_local_state;
+
+	explicit PyTVFArrowLocalState(unique_ptr<LocalTableFunctionState> arrow_local)
+	    : arrow_local_state(std::move(arrow_local)) {
+	}
+};
+
+static void PyTVFArrowScanFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
+	// Delegates to ArrowScanFunction
+	auto &gs = input.global_state->Cast<PyTVFArrowGlobalState>();
+	auto &ls = input.local_state->Cast<PyTVFArrowLocalState>();
+
+	TableFunctionInput arrow_input(gs.arrow_bind_data.get(), ls.arrow_local_state.get(), gs.arrow_global_state.get());
+	ArrowTableFunction::ArrowScanFunction(context, arrow_input, output);
+}
+
+static unique_ptr<PyTVFBindData> PyTVFBindInternal(ClientContext &context, TableFunctionBindInput &in,
+                                                   vector<LogicalType> &return_types, vector<string> &return_names) {
+	// Disable progress bar to prevent GIL deadlock with Jupyter
+	// TODO: Decide if this is still needed - was a problem when fully materializing, but switched to streaming
+	ClientConfig::GetConfig(context).enable_progress_bar = false;
+	ClientConfig::GetConfig(context).system_progress_bar_disable_reason =
+	    "Table Valued Functions do not support the progress bar";
+
+	if (!in.info) {
+		throw InvalidInputException("Table function '%s' missing function info", in.table_function.name);
+	}
+
+	auto &tvf_info = in.info->Cast<PyTVFInfo>();
+	return_types = tvf_info.return_types;
+	return_names = tvf_info.return_names;
+
+	// Acquire gil before copying py::function
+	py::gil_scoped_acquire gil;
+	return make_uniq<PyTVFBindData>(in.table_function.name, in.inputs, in.named_parameters, return_types, return_names,
+	                                tvf_info.callable);
+}
+
+static unique_ptr<FunctionData> PyTVFTuplesBindFunction(ClientContext &context, TableFunctionBindInput &in,
+                                                        vector<LogicalType> &return_types,
+                                                        vector<string> &return_names) {
+	auto bd = PyTVFBindInternal(context, in, return_types, return_names);
+	return std::move(bd);
+}
+
+static unique_ptr<FunctionData> PyTVFArrowBindFunction(ClientContext &context, TableFunctionBindInput &in,
+                                                       vector<LogicalType> &return_types,
+                                                       vector<string> &return_names) {
+	auto bd = PyTVFBindInternal(context, in, return_types, return_names);
+	return std::move(bd);
+}
+
+static py::object CallPythonTVF(ClientContext &context, PyTVFBindData &bd) {
+	py::gil_scoped_acquire gil;
+
+	// positional arguments
+	py::tuple args(bd.args.size());
+	for (idx_t i = 0; i < bd.args.size(); i++) {
+		args[i] = PythonObject::FromValue(bd.args[i], bd.args[i].type(), context.GetClientProperties());
+	}
+
+	// keyword arguments
+	py::dict kwargs;
+	for (auto &kv : bd.kwargs) {
+		kwargs[py::str(kv.first)] = PythonObject::FromValue(kv.second, kv.second.type(), context.GetClientProperties());
+	}
+
+	// Call Python function
+	auto &callable = bd.python_objects.LastAddedObject();
+	py::object result = callable(*args, **kwargs);
+
+	if (result.is_none()) {
+		throw InvalidInputException("Table function '%s' returned None, expected iterable or Arrow table",
+		                            bd.func_name);
+	}
+
+	return result;
+}
+
+static unique_ptr<GlobalTableFunctionState> PyTVFTuplesInitGlobal(ClientContext &context, TableFunctionInitInput &in) {
+	auto &bd = in.bind_data->Cast<PyTVFBindData>();
+	auto gs = make_uniq<PyTVFTuplesGlobalState>();
+
+	{
+		py::gil_scoped_acquire gil;
+		// const_cast is safe here - we only read from python_objects, not modify bind_data structure
+		py::object result = CallPythonTVF(context, const_cast<PyTVFBindData &>(bd));
+		try {
+			py::iterator it = py::iter(result);
+			gs->python_objects.Push(std::move(it));
+			gs->iterator_exhausted = false;
+		} catch (const py::error_already_set &e) {
+			throw InvalidInputException("Table function '%s' returned non-iterable result: %s", bd.func_name, e.what());
+		}
+	}
+
+	return std::move(gs);
+}
+
+static unique_ptr<GlobalTableFunctionState> PyTVFArrowInitGlobal(ClientContext &context, TableFunctionInitInput &in) {
+	auto &bd = in.bind_data->Cast<PyTVFBindData>();
+	auto gs = make_uniq<PyTVFArrowGlobalState>();
+
+	{
+		py::gil_scoped_acquire gil;
+
+		py::object result = CallPythonTVF(context, const_cast<PyTVFBindData &>(bd));
+		PyObject *ptr = result.ptr();
+
+		// TODO: Should we verify this is an arrow table, or just fail later
+		gs->python_objects.Push(std::move(result));
+
+		gs->arrow_factory = make_uniq<PythonTableArrowArrayStreamFactory>(ptr, context.GetClientProperties(),
+		                                                                  DBConfig::GetConfig(context));
+	}
+
+	// Build bind input for Arrow scan
+	vector<Value> children;
+	children.push_back(Value::POINTER(CastPointerToValue(gs->arrow_factory.get())));
+	children.push_back(Value::POINTER(CastPointerToValue(PythonTableArrowArrayStreamFactory::Produce)));
+	children.push_back(Value::POINTER(CastPointerToValue(PythonTableArrowArrayStreamFactory::GetSchema)));
+
+	TableFunctionRef empty_ref;
+	duckdb::TableFunction dummy_tf;
+	dummy_tf.name = "PyTVFArrowWrapper";
+
+	named_parameter_map_t named_params;
+	vector<LogicalType> input_types;
+	vector<string> input_names;
+
+	TableFunctionBindInput bind_input(children, named_params, input_types, input_names, nullptr, nullptr, dummy_tf,
+	                                  empty_ref);
+
+	vector<LogicalType> return_types;
+	vector<string> return_names;
+	gs->arrow_bind_data = ArrowTableFunction::ArrowScanBind(context, bind_input, return_types, return_names);
+
+	// Validate Arrow schema matches declared
+	if (return_types.size() != bd.return_types.size()) {
+		throw InvalidInputException("Schema mismatch in table function '%s': "
+		                            "Arrow table has %lu columns but %lu were declared",
+		                            bd.func_name, return_types.size(), bd.return_types.size());
+	}
+
+	// Check column types match
+	for (idx_t i = 0; i < return_types.size(); i++) {
+		if (return_types[i] != bd.return_types[i]) {
+			throw InvalidInputException("Schema mismatch in table function '%s' at column %lu: "
+			                            "Arrow table has type %s but %s was declared",
+			                            bd.func_name, i, return_types[i].ToString().c_str(),
+			                            bd.return_types[i].ToString().c_str());
+		}
+	}
+
+	gs->num_columns = return_types.size();
+	vector<column_t> all_columns;
+	for (idx_t i = 0; i < gs->num_columns; i++) {
+		all_columns.push_back(i);
+	}
+
+	TableFunctionInitInput init_input(gs->arrow_bind_data.get(), all_columns, all_columns, in.filters.get());
+	gs->arrow_global_state = ArrowTableFunction::ArrowScanInitGlobal(context, init_input);
+
+	return std::move(gs);
+}
+
+static unique_ptr<LocalTableFunctionState> PyTVFArrowInitLocal(ExecutionContext &context, TableFunctionInitInput &in,
+                                                               GlobalTableFunctionState *gstate) {
+	auto &gs = gstate->Cast<PyTVFArrowGlobalState>();
+
+	vector<column_t> all_columns;
+	for (idx_t i = 0; i < gs.num_columns; i++) {
+		all_columns.push_back(i);
+	}
+
+	TableFunctionInitInput arrow_init(gs.arrow_bind_data.get(), all_columns, all_columns, in.filters.get());
+	auto arrow_local_state =
+	    ArrowTableFunction::ArrowScanInitLocalInternal(context.client, arrow_init, gs.arrow_global_state.get());
+
+	return make_uniq<PyTVFArrowLocalState>(std::move(arrow_local_state));
+}
+
+duckdb::TableFunction DuckDBPyConnection::CreateTableFunctionFromCallable(const std::string &name,
+                                                                          const py::function &callable,
+                                                                          const py::object &parameters,
+                                                                          const py::object &schema,
+                                                                          PythonTVFType type) {
+
+	// Schema
+	if (schema.is_none()) {
+		throw InvalidInputException("Table functions require a schema.");
+	}
+
+	vector<LogicalType> types;
+	vector<string> names;
+	for (auto c : py::iter(schema)) {
+		auto item = py::cast<py::object>(c);
+		if (py::isinstance<py::str>(item)) {
+			throw InvalidInputException("Invalid schema format: expected [name, type] pairs, got string '%s'",
+			                            py::str(item).cast<std::string>());
+		}
+		if (!py::hasattr(item, "__getitem__") || py::len(item) < 2) {
+			throw InvalidInputException("Invalid schema format: each schema item must be a [name, type] pair");
+		}
+		names.emplace_back(py::str(item[py::int_(0)]));
+		types.emplace_back(TransformStringToLogicalType(py::str(item[py::int_(1)])));
+	}
+
+	if (types.empty()) {
+		throw InvalidInputException("Table function '%s' schema cannot be empty", name);
+	}
+
+	duckdb::TableFunction tf;
+	switch (type) {
+	case PythonTVFType::TUPLES:
+		tf =
+		    duckdb::TableFunction(name, {}, +PyTVFTuplesScanFunction, +PyTVFTuplesBindFunction, +PyTVFTuplesInitGlobal);
+		break;
+	case PythonTVFType::ARROW_TABLE:
+		tf = duckdb::TableFunction(name, {}, +PyTVFArrowScanFunction, +PyTVFArrowBindFunction, +PyTVFArrowInitGlobal,
+		                           +PyTVFArrowInitLocal);
+		break;
+	default:
+		throw InvalidInputException("Unknown return type for table function '%s'", name);
+	}
+
+	// Store the Python callable and schema
+	tf.function_info = make_shared_ptr<PyTVFInfo>(callable, types, names, type);
+
+	// args
+	tf.varargs = LogicalType::ANY;
+	tf.named_parameters["args"] = LogicalType::ANY;
+
+	// kwargs
+	if (!parameters.is_none()) {
+		for (auto &param : py::cast<py::list>(parameters)) {
+			string param_name = py::str(param);
+			tf.named_parameters[param_name] = LogicalType::ANY;
+		}
+	}
+
+	return tf;
+}
+
+} // namespace duckdb

--- a/tests/fast/tvf/test_arrow.py
+++ b/tests/fast/tvf/test_arrow.py
@@ -1,0 +1,204 @@
+from typing import Iterator
+
+import pytest
+
+import duckdb
+from duckdb.functional import PythonTVFType
+
+
+def simple_generator(count: int = 10) -> Iterator[tuple[str, int]]:
+    for i in range(count):
+        yield (f"name_{i}", i)
+
+
+def simple_arrow_table(count: int):
+    import pyarrow as pa
+
+    data = {
+        "id": list(range(count)),
+        "value": [i * 2 for i in range(count)],
+        "name": [f"row_{i}" for i in range(count)],
+    }
+    return pa.table(data)
+
+
+def test_arrow_small(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            "simple_arrow",
+            simple_arrow_table,
+            schema=[("x", "BIGINT"), ("y", "VARCHAR")],  # Wrong schema!
+            type=PythonTVFType.ARROW_TABLE,
+        )
+
+        with pytest.raises(Exception) as exc_info:
+            result = conn.execute("SELECT * FROM simple_arrow(5)").fetchall()
+
+        assert (
+            "Vector::Reference" in str(exc_info.value)
+            or "schema" in str(exc_info.value).lower()
+        )
+
+
+def test_arrow_large_1(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        n = 2048 * 1000
+
+        conn.create_table_function(
+            "large_arrow",
+            simple_arrow_table,
+            schema=[("id", "BIGINT"), ("value", "BIGINT"), ("name", "VARCHAR")],
+            type="arrow_table",
+        )
+
+        result = conn.execute(
+            "SELECT COUNT(*) FROM large_arrow(?)", parameters=(n,)
+        ).fetchone()
+        assert result[0] == n
+
+        df = conn.sql(f"SELECT * FROM large_arrow({n}) LIMIT 10").df()
+        assert len(df) == 10
+        assert df["id"].tolist() == list(range(10))
+
+        arrow_result = conn.execute(
+            "SELECT * FROM large_arrow(?)", parameters=(n,)
+        ).fetch_arrow_table()
+        assert len(arrow_result) == n
+
+        result = conn.sql(
+            "SELECT SUM(value) FROM large_arrow(?)", params=(n,)
+        ).fetchone()
+        expected_sum = sum(i * 2 for i in range(n))
+        assert result[0] == expected_sum
+
+
+def test_large_arrow_execute(tmp_path):
+    pytest.importorskip("pyarrow")
+
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=simple_generator,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.execute(
+            "SELECT * FROM gen_function(?)",
+            parameters=(count,),
+        ).fetch_arrow_table()
+
+        assert len(result) == count
+
+
+def test_large_arrow_sql(tmp_path):
+    pytest.importorskip("pyarrow")
+
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=simple_generator,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.sql(
+            "SELECT * FROM gen_function(?)",
+            params=(count,),
+        ).fetch_arrow_table()
+
+        assert len(result) == count
+
+
+def test_arrowbatched_execute(tmp_path):
+    pytest.importorskip("pyarrow")
+
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=simple_generator,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.execute(
+            "SELECT * FROM gen_function(?)",
+            parameters=(count,),
+        ).fetch_record_batch()
+
+        result = conn.execute(
+            f"SELECT * FROM gen_function({count})",
+        ).fetch_record_batch()
+
+        c = 0
+        for batch in result:
+            c += batch.num_rows
+        assert c == count
+
+
+def test_arrowbatched_sql_relation(tmp_path):
+    pytest.importorskip("pyarrow")
+
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=simple_generator,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.sql(
+            f"SELECT * FROM gen_function({count})",
+        ).fetch_arrow_reader()
+
+        c = 0
+        for batch in result:
+            c += batch.num_rows
+        assert c == count
+
+
+def test_arrowbatched_sql_materialized(tmp_path):
+    pytest.importorskip("pyarrow")
+
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=simple_generator,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        # passing parameters makes it non-lazy /materialized
+        result = conn.sql(
+            "SELECT * FROM gen_function(?)",
+            params=(count,),
+        ).fetch_arrow_reader()
+
+        c = 0
+        for batch in result:
+            c += batch.num_rows
+        assert c == count

--- a/tests/fast/tvf/test_arrow_schema.py
+++ b/tests/fast/tvf/test_arrow_schema.py
@@ -1,0 +1,125 @@
+"""Test Arrow TVF schema validation"""
+
+import pytest
+
+import duckdb
+from duckdb.functional import PythonTVFType
+
+
+def simple_arrow_table(count: int = 10):
+    import pyarrow as pa
+
+    data = {
+        "id": list(range(count)),
+        "value": [i * 2 for i in range(count)],
+        "name": [f"row_{i}" for i in range(count)],
+    }
+    return pa.table(data)
+
+
+def test_arrow_correct_schema(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            "arrow_func",
+            simple_arrow_table,
+            schema=[("id", "BIGINT"), ("value", "BIGINT"), ("name", "VARCHAR")],
+            type=PythonTVFType.ARROW_TABLE,
+        )
+
+        result = conn.execute("SELECT * FROM arrow_func(5)").fetchall()
+        assert len(result) == 5
+        assert result[0] == (0, 0, "row_0")
+
+
+def test_arrow_more_columns(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        # table has 3 cols, but declare only 2
+        conn.create_table_function(
+            "arrow_func",
+            simple_arrow_table,
+            schema=[("x", "BIGINT"), ("y", "BIGINT")],  # Missing third column
+            type=PythonTVFType.ARROW_TABLE,
+        )
+
+        with pytest.raises(duckdb.InvalidInputException) as exc_info:
+            conn.execute("SELECT * FROM arrow_func(5)").fetchall()
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "schema mismatch" in error_msg
+            or "3 columns" in error_msg
+            or "2 were declared" in error_msg
+        )
+
+
+def test_arrow_fewer_columns(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        # table has 3 columns, but declare 4
+        conn.create_table_function(
+            "arrow_func",
+            simple_arrow_table,
+            schema=[
+                ("id", "BIGINT"),
+                ("value", "BIGINT"),
+                ("name", "VARCHAR"),
+                ("extra", "INT"),  # Extra column that doesn't exist
+            ],
+            type=PythonTVFType.ARROW_TABLE,
+        )
+
+        with pytest.raises(duckdb.InvalidInputException) as exc_info:
+            conn.execute("SELECT * FROM arrow_func(5)").fetchall()
+
+        error_msg = str(exc_info.value).lower()
+        assert (
+            "schema mismatch" in error_msg
+            or "3 columns" in error_msg
+            or "4 were declared" in error_msg
+        )
+
+
+def test_arrow_type_mismatch(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            "arrow_func",
+            simple_arrow_table,
+            schema=[
+                ("id", "VARCHAR"),  # Wrong type - should be BIGINT
+                ("value", "BIGINT"),
+                ("name", "VARCHAR"),
+            ],
+            type=PythonTVFType.ARROW_TABLE,
+        )
+
+        with pytest.raises(duckdb.InvalidInputException) as exc_info:
+            conn.execute("SELECT * FROM arrow_func(5)").fetchall()
+
+        error_msg = str(exc_info.value).lower()
+        assert "type" in error_msg or "mismatch" in error_msg
+
+
+def test_arrow_name_mismatch_allowed(tmp_path):
+    pa = pytest.importorskip("pyarrow")
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            "arrow_func",
+            simple_arrow_table,
+            schema=[
+                ("a", "BIGINT"),  # Arrow has 'id'
+                ("b", "BIGINT"),  # Arrow has 'value'
+                ("c", "VARCHAR"),  # Arrow has 'name'
+            ],
+            type=PythonTVFType.ARROW_TABLE,
+        )
+
+        result = conn.execute("SELECT * FROM arrow_func(3)").fetchall()
+        assert len(result) == 3

--- a/tests/fast/tvf/test_register.py
+++ b/tests/fast/tvf/test_register.py
@@ -1,0 +1,328 @@
+import pytest
+
+import duckdb
+
+
+def test_registry_collision(tmp_path):
+    """Two tvfs on different connections with same name""" ""
+    conn1 = duckdb.connect(tmp_path / "db1.db")
+    conn2 = duckdb.connect(tmp_path / "db2.db")
+
+    def func_for_conn1():
+        return [("conn1_data", 1)]
+
+    def func_for_conn2():
+        return [("conn2_data", 2)]
+
+    schema = [("name", "VARCHAR"), ("id", "INT")]
+
+    conn1.create_table_function(
+        name="same_name",
+        callable=func_for_conn1,
+        parameters=None,
+        schema=schema,
+        type="tuples",
+    )
+
+    conn2.create_table_function(
+        name="same_name",
+        callable=func_for_conn2,
+        parameters=None,
+        schema=schema,
+        type="tuples",
+    )
+
+    result1 = conn1.execute("SELECT * FROM same_name()").fetchall()
+    assert result1[0][0] == "conn1_data"
+    assert result1[0][1] == 1
+
+    result2 = conn2.execute("SELECT * FROM same_name()").fetchall()
+    assert result2[0][0] == "conn2_data"
+    assert result2[0][1] == 2
+
+    result1 = conn1.sql("SELECT * FROM same_name()").fetchall()
+    assert result1[0][0] == "conn1_data"
+    assert result1[0][1] == 1
+
+    conn1.close()
+    conn2.close()
+
+
+def test_replace_without_unregister(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def func_v1():
+            return [("version_1", 1)]
+
+        def func_v2():
+            return [("version_2", 2)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function("test_func", func_v1, schema=schema, type="tuples")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "version_1"
+        assert result[0][1] == 1
+
+        with pytest.raises(duckdb.NotImplementedException) as exc_info:
+            conn.create_table_function(
+                "test_func", func_v2, schema=schema, type="tuples"
+            )
+        assert "already registered" in str(exc_info.value)
+
+
+def test_replace_after_unregister(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def func_v1():
+            return [("version_1", 1)]
+
+        def func_v2():
+            return [("version_2", 2)]
+
+        def func_v3():
+            return [("version_3", 3)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function("test_func", func_v1, schema=schema, type="tuples")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "version_1"
+
+        conn.unregister_table_function("test_func")
+        conn.create_table_function("test_func", func_v2, schema=schema, type="tuples")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "version_2"
+
+        conn.unregister_table_function("test_func")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "version_2"
+
+        conn.create_table_function("test_func", func_v3, schema=schema, type="tuples")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "version_3"
+        assert result[0][1] == 3
+
+
+def test_multiple_replacements(tmp_path):
+    """Replacing TVFs multiple times"""
+    with duckdb.connect(tmp_path / "test.db") as conn:
+        schema = [("value", "INT")]
+
+        for i in range(1, 6):
+
+            def make_func(val=i):
+                def func():
+                    return [(val,)]
+
+                return func
+
+            if i > 1:
+                conn.unregister_table_function("counter")
+
+            conn.create_table_function(
+                "counter", make_func(), schema=schema, type="tuples"
+            )
+
+            result = conn.execute("SELECT * FROM counter()").fetchone()
+            assert result[0] == i
+
+
+def test_replacement_with_different_schemas(tmp_path):
+    """Changing schema with replacements"""
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def func_v1():
+            return [("test", 1)]
+
+        def func_v2():
+            return [("modified", 2, 3.14)]
+
+        schema_v1 = [("name", "VARCHAR"), ("id", "INT")]
+        conn.create_table_function(
+            "evolving_func", func_v1, schema=schema_v1, type="tuples"
+        )
+
+        result = conn.execute("SELECT * FROM evolving_func()").fetchall()
+        assert len(result[0]) == 2
+        assert result[0][0] == "test"
+
+        schema_v2 = [("name", "VARCHAR"), ("id", "INT"), ("value", "DOUBLE")]
+        conn.unregister_table_function("evolving_func")  # Must unregister first
+        conn.create_table_function(
+            "evolving_func", func_v2, schema=schema_v2, type="tuples"
+        )
+
+        result = conn.execute("SELECT * FROM evolving_func()").fetchall()
+        assert len(result[0]) == 3
+        assert result[0][0] == "modified"
+        assert result[0][2] == 3.14
+
+
+def test_replacement_2(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def func_v1():
+            return [("v1",)]
+
+        def func_v2():
+            return [("v2",)]
+
+        schema = [("version", "VARCHAR")]
+
+        conn.create_table_function(
+            "tracked_func", func_v1, schema=schema, type="tuples"
+        )
+
+        conn.unregister_table_function("tracked_func")  # Must unregister first
+        conn.create_table_function(
+            "tracked_func", func_v2, schema=schema, type="tuples"
+        )
+
+        conn.unregister_table_function("tracked_func")
+
+        with pytest.raises(duckdb.InvalidInputException) as exc_info:
+            conn.unregister_table_function("tracked_func")
+        assert "No table function by the name of 'tracked_func'" in str(exc_info.value)
+
+        result = conn.execute("SELECT * FROM tracked_func()").fetchone()
+        assert result[0] == "v2"
+
+
+def test_sql_drop_table_function(tmp_path):
+    """Documents current behavior - that dropping functions has no effect on TVFs"""
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def test_func():
+            return [("test_value", 1)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+        conn.create_table_function("test_func", test_func, schema=schema, type="tuples")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "test_value"
+        assert result[0][1] == 1
+
+        with pytest.raises(Exception):
+            conn.execute("DROP FUNCTION test_func")
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert result[0][0] == "test_value"
+        assert result[0][1] == 1
+
+
+def test_unregister_table_function(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def simple_function():
+            return [("test_value", 1)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function(
+            name="test_func",
+            callable=simple_function,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert len(result) == 1
+        assert result[0][0] == "test_value"
+        assert result[0][1] == 1
+
+        conn.unregister_table_function("test_func")
+
+        # TODO: Decide whether we want to fail or keep this behavior
+        result = conn.execute("SELECT * FROM test_func()").fetchall()
+        assert len(result) == 1
+        assert result[0][0] == "test_value"
+        assert result[0][1] == 1
+
+        with pytest.raises(duckdb.InvalidInputException) as exc_info:
+            conn.unregister_table_function("test_func")
+
+        assert "No table function by the name of 'test_func'" in str(exc_info.value)
+
+
+def test_unregister_doesntexist(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+        with pytest.raises(duckdb.InvalidInputException) as exc_info:
+            conn.unregister_table_function("nonexistent_func")
+
+        assert "No table function by the name of 'nonexistent_func'" in str(
+            exc_info.value
+        )
+
+
+def test_reregister(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def func_v1():
+            return [("version_1", 1)]
+
+        def func_v2():
+            return [("version_2", 2)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function(
+            name="versioned_func",
+            callable=func_v1,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.execute("SELECT * FROM versioned_func()").fetchall()
+        assert result[0][0] == "version_1"
+
+        conn.unregister_table_function("versioned_func")
+
+        conn.create_table_function(
+            name="versioned_func",
+            callable=func_v2,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.execute("SELECT * FROM versioned_func()").fetchall()
+        assert result[0][0] == "version_2"
+
+
+def test_unregister_multi(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+        cursor1 = conn.cursor()
+        cursor2 = conn.cursor()
+
+        def test_func():
+            return [("test_data", 1)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        cursor1.create_table_function(
+            name="shared_func",
+            callable=test_func,
+            schema=schema,
+            type="tuples",
+        )
+
+        result1 = cursor1.execute("SELECT * FROM shared_func()").fetchall()
+        assert result1[0][0] == "test_data"
+
+        result2 = cursor2.execute("SELECT * FROM shared_func()").fetchall()
+        assert result2[0][0] == "test_data"
+
+        cursor1.unregister_table_function("shared_func")
+
+        # TODO: Decide whether to keep this unregister behavior
+        result1 = cursor1.execute("SELECT * FROM shared_func()").fetchall()
+        assert result1[0][0] == "test_data"
+
+        result2 = cursor2.execute("SELECT * FROM shared_func()").fetchall()
+        assert result2[0][0] == "test_data"

--- a/tests/fast/tvf/test_tuples.py
+++ b/tests/fast/tvf/test_tuples.py
@@ -1,0 +1,298 @@
+from typing import Iterator
+
+import pytest
+
+import duckdb
+from duckdb.functional import PythonTVFType
+
+
+def simple_generator(count: int = 10) -> Iterator[tuple[str, int]]:
+    for i in range(count):
+        yield (f"name_{i}", i)
+
+
+def simple_pylist(count: int = 10) -> list[tuple[str, int]]:
+    return [(f"name_{i}", i) for i in range(count)]
+
+
+def simple_pylistlist(count: int = 10) -> list[list[str, int]]:
+    return [[f"name_{i}", i] for i in range(count)]
+
+
+@pytest.mark.parametrize(
+    "gen_function", [simple_generator, simple_pylist, simple_pylistlist]
+)
+def test_simple(tmp_path, gen_function):
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=gen_function,
+            parameters=None,
+            schema=schema,
+            type=PythonTVFType.TUPLES,
+        )
+
+        result = conn.sql("SELECT * FROM gen_function(5)").fetchall()
+
+        assert len(result) == 5
+        assert result[0][0] == "name_0"
+        assert result[-1][-1] == 4
+
+        result = conn.sql("SELECT * FROM gen_function()").fetchall()
+
+        assert len(result) == 10
+        assert result[-1][0] == "name_9"
+        assert result[-1][1] == 9
+
+
+@pytest.mark.parametrize("gen_function", [simple_generator])
+def test_simple_large_fetchall(tmp_path, gen_function):
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=gen_function,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.sql(
+            "SELECT * FROM gen_function(?)",
+            params=(count,),
+        ).fetchall()
+
+        assert len(result) == count
+        assert result[0][0] == "name_0"
+        assert result[-1][-1] == count - 1
+
+
+@pytest.mark.parametrize("gen_function", [simple_generator])
+def test_simple_large_df(tmp_path, gen_function):
+    count = 2048 * 1000
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=gen_function,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.sql(
+            "SELECT * FROM gen_function(?)",
+            params=(count,),
+        ).df()
+
+        assert len(result) == count
+
+
+def test_no_schema(tmp_path):
+    def gen_function(n):
+        return n
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        with pytest.raises(duckdb.InvalidInputException):
+            conn.create_table_function(
+                name="gen_function",
+                callable=gen_function,
+                type="tuples",
+            )
+
+
+def test_returns_scalar(tmp_path):
+    def gen_function(n):
+        return n
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        with pytest.raises(duckdb.InvalidInputException):
+            conn.create_table_function(
+                name="gen_function",
+                callable=gen_function,
+                parameters=["n"],
+                schema=["value"],
+                type="tuples",
+            )
+
+
+def test_returns_list_scalar(tmp_path):
+    def gen_function_2(n):
+        return [n]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        with pytest.raises(duckdb.InvalidInputException):
+            conn.create_table_function(
+                name="gen_function_2",
+                callable=gen_function_2,
+                schema=["value"],
+                type="tuples",
+            )
+
+
+def test_returns_wrong_schema(tmp_path):
+    def gen_function(n):
+        return list[range(n)]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=gen_function,
+            schema=schema,
+            type="tuples",
+        )
+        with pytest.raises(duckdb.InvalidInputException):
+            conn.sql("SELECT * FROM gen_function(5)").fetchall()
+
+
+def test_kwargs(tmp_path):
+    def simple_pylist(count, foo=10):
+        return [(f"name_{i}_{foo}", i) for i in range(count)]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            name="simple_pylist",
+            callable=simple_pylist,
+            parameters=["count"],
+            schema=[["name", "VARCHAR"], ["id", "INT"]],
+            type="tuples",
+        )
+        result = conn.sql("SELECT * FROM simple_pylist(3)").fetchall()
+        assert result[-1][0] == "name_2_10"
+
+        result = conn.sql("SELECT * FROM simple_pylist(count:=3)").fetchall()
+        assert result[-1][0] == "name_2_10"
+
+        with pytest.raises(duckdb.BinderException):
+            result = conn.sql(
+                "SELECT * FROM simple_pylist(count:=3, foo:=2)"
+            ).fetchall()
+
+
+def test_large_2(tmp_path):
+    """aggregtes and filtering"""
+    with duckdb.connect(tmp_path / "test.db") as conn:
+        count = 500000
+
+        def large_generator():
+            return [(f"item_{i}", i) for i in range(count)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function(
+            name="large_tvf",
+            callable=large_generator,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        result = conn.execute("SELECT COUNT(*) FROM large_tvf()").fetchone()
+        assert result[0] == count
+
+        result = conn.sql("SELECT MAX(id) FROM large_tvf()").fetchone()
+        assert result[0] == count - 1
+
+        result = conn.execute(
+            "SELECT COUNT(*) FROM large_tvf() WHERE id < 100"
+        ).fetchone()
+        assert result[0] == 100
+
+
+def test__parameters(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def parametrized_function(count=10, prefix="item"):
+            return [(f"{prefix}_{i}", i) for i in range(count)]
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function(
+            name="param_tvf",
+            callable=parametrized_function,
+            parameters=["count", "prefix"],
+            schema=schema,
+            type="tuples",
+        )
+
+        result1 = conn.execute("SELECT COUNT(*) FROM param_tvf(5, 'test')").fetchone()
+        assert result1[0] == 5
+
+        result2 = conn.execute(
+            "SELECT COUNT(*) FROM param_tvf(20, prefix:='data')"
+        ).fetchone()
+        assert result2[0] == 20
+
+        # Test parameter order
+        result3 = conn.execute(
+            "SELECT name FROM param_tvf(3, 'xyz') ORDER BY id LIMIT 1"
+        ).fetchone()
+        assert result3[0] == "xyz_0"
+
+
+def test_error(tmp_path):
+    with duckdb.connect(tmp_path / "test.db") as conn:
+
+        def error_function():
+            raise ValueError("Intentional")
+
+        schema = [("name", "VARCHAR"), ("id", "INT")]
+
+        conn.create_table_function(
+            name="error_tvf",
+            callable=error_function,
+            parameters=None,
+            schema=schema,
+            type="tuples",
+        )
+
+        with pytest.raises(Exception):
+            conn.execute("SELECT * FROM error_tvf()").fetchall()
+
+
+def test_callable_refcount(tmp_path):
+    import sys
+
+    def gen_function(n):
+        return [(f"name_{i}", i) for i in range(n)]
+
+    initial_refcount = sys.getrefcount(gen_function)
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        schema = [["name", "VARCHAR"], ["id", "INT"]]
+
+        conn.create_table_function(
+            name="gen_function",
+            callable=gen_function,
+            schema=schema,
+            type="tuples",
+        )
+
+        after_register_refcount = sys.getrefcount(gen_function)
+        assert after_register_refcount > initial_refcount, (
+            f"Expected refcount to increase after registration, "
+            f"but got {after_register_refcount} (initial: {initial_refcount})"
+        )
+
+        for _ in range(3):
+            result = conn.sql("SELECT * FROM gen_function(5)").fetchall()
+            assert len(result) == 5
+
+        after_execution_refcount = sys.getrefcount(gen_function)
+        assert after_execution_refcount == after_register_refcount, (
+            f"Expected refcount to remain stable after execution, "
+            f"but got {after_execution_refcount} (after register: {after_register_refcount})"
+        )
+
+    final_refcount = sys.getrefcount(gen_function)
+    assert final_refcount == initial_refcount, (
+        f"Expected refcount to return to initial after unregistration, "
+        f"but got {final_refcount} (initial: {initial_refcount})"
+    )

--- a/tests/fast/tvf/test_tuples_datatypes.py
+++ b/tests/fast/tvf/test_tuples_datatypes.py
@@ -1,0 +1,94 @@
+import pytest
+
+import duckdb
+
+
+def test_bigint_params(tmp_path):
+    def bigint_func(big_value):
+        return [(big_value, big_value + 1, big_value * 2)]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            name="bigint_func",
+            callable=bigint_func,
+            schema=[["orig", "BIGINT"], ["plus_one", "BIGINT"], ["doubled", "BIGINT"]],
+            type="tuples",
+        )
+
+        large_val = 4611686018427387900  # Half of max int64
+        result = conn.sql(
+            f"SELECT * FROM bigint_func(?)", params=(large_val,)
+        ).fetchall()
+        assert result[0][0] == large_val
+        assert result[0][1] == large_val + 1
+        assert result[0][2] == large_val * 2
+
+
+def test_hugeint_params(tmp_path):
+    def hugeint_func(huge_value):
+        return [(huge_value, huge_value + 1)]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            name="hugeint_func",
+            callable=hugeint_func,
+            schema=[["orig", "HUGEINT"], ["plus_one", "HUGEINT"]],
+            type="tuples",
+        )
+
+        huge_val = 9223372036854775808
+        result = conn.sql(
+            f"SELECT * FROM hugeint_func(?)", params=(huge_val,)
+        ).fetchall()
+        assert result[0][0] == huge_val
+        assert result[0][1] == huge_val + 1
+
+
+def test_decimal_params(tmp_path):
+    from decimal import Decimal
+
+    def decimal_func(dec_value):
+        if isinstance(dec_value, float):
+            result = dec_value * 2
+        else:
+            result = Decimal(str(dec_value)) * 2
+        return [(dec_value, result)]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            name="decimal_func",
+            callable=decimal_func,
+            schema=[["orig", "DECIMAL(10,2)"], ["doubled", "DECIMAL(10,2)"]],
+            type="tuples",
+        )
+
+        result = conn.sql(
+            "SELECT * FROM decimal_func(?::decimal)", params=(123.45,)
+        ).fetchall()
+        assert float(result[0][0]) == 123.45
+        assert float(result[0][1]) == 246.90
+
+
+def test_uuid_params(tmp_path):
+    import uuid
+
+    def uuid_func(uuid_value):
+        if isinstance(uuid_value, str):
+            parsed = uuid.UUID(uuid_value)
+        else:
+            parsed = uuid_value
+        return [(str(uuid_value),)]
+
+    with duckdb.connect(tmp_path / "test.duckdb") as conn:
+        conn.create_table_function(
+            name="uuid_func",
+            callable=uuid_func,
+            schema=[("orig", "UUID")],
+            type="tuples",
+        )
+
+        test_uuid = "550e8400-e29b-41d4-a716-446655440000"
+        result = conn.sql(
+            f"SELECT * FROM uuid_func(?::uuid)", params=(test_uuid,)
+        ).fetchall()
+        assert str(result[0][0]) == test_uuid


### PR DESCRIPTION
Per discussion https://github.com/duckdb/duckdb-python/discussions/84, this PR implements Python Table Valued Functions. (aka: User Defined Table Functions)\*.

Table Valued Functions\* allow Python callables to be registered as DuckDB Table Functions, returning either (`Iterator[Sequence]`) or an Arrow table. 

This is implemented primarily in `python_tvf.cpp`. Tuple TVFs scan the py::iter from the Callable. Arrow TVFs delegate to ArrowTableFunction.

\* While the main code is ready for review, I'll need a pointer on how to properly add and regenerate the bindings. I added them manually in pyconnection.cpp. As I know some work was being done in the stubs and didn't want to conflict. 

\*\* Getting the GIL and reference counting part right took a bit of work, especially around destruction. I found PythonObjectContainer late (after trying other approaches), so please let me know if this is the right approach. 

#### Changes in this PR
- New functions: create_table_function and unregister_table_function
- New enum: PythonTVFType
- Add: `	case_insensitive_map_t<unique_ptr<ExternalDependency>> registered_table_functions;` to PyConnection
- Change: PyConnection now releases the GIL when materializing.. this was needed to prevent deadlock where the TVF needs the GIL to scan. 
- Tests: Added tests for TUPLES, ARROW_TABLE, along with registration & schema mismatches. 

#### Registration
This implementation adds two new functions:
- create_table_function
- unregister_table_function

```py
import duckdb
conn = duckdb.connect()

conn.create_table_function(
    name="gen_function",
    callable=lambda count: [(f"name_{i}", i) for i in range(count)] ,
    parameters=["count"],
    schema=[["name", "VARCHAR"], ["id", "INT"]],
    type="tuples", # or "arrow_table" or PythonTVFType.TUPLES or PythonTVFType.ARROW_TABLE
)

table = conn.execute("select * from gen_function(count:=10)").fetch_arrow_table()
```

#### Parameters

Parameters are declared as a list of parameter names, such as `parameters = ["col1", "col2"]`. 

- Positional parameters do not need to be declared: `parameters=None` still allows positional parameters to be called. 
- Parameters called by name need to be declared: `myfunction(count:=10)` 

#### Schema

The schema of a Table Function must be declared at bind time. This is done by capturing the return type at registration time. \*

Schemas are defined as `List[Tuple[str,str]]`, where each tuple is a pair of Column Name and Data Type. 

\* It's possible, but not implemented, to infer the schema for Arrow Tables rather than requiring it. Or, perhaps, to be more lenient. 

#### Test Failures:

There's two test failures: 
- tests/fast/api/test_duckdb_connection.py::TestDuckDBConnection::test_wrap_coverage : If/when the main code is reviewed, just need help figuring out how to properly do this. I didn't want to interfere with the stubs work being done. 
- tests/fast/arrow/test_polars.py::TestPolars::test_polars_lazy_pushdown_numeric: See https://github.com/duckdb/duckdb-python/issues/98

#### Tuples Example with positional args
```py
import duckdb

def simple_generator(count: int = 10):
    for i in range(count):
        yield (f"name_{i}", i)

with duckdb.connect() as conn:
        conn.create_table_function(
            name="gen_function",
            callable=simple_generator,
            parameters=["count"],
            schema=schema,
            type="tuples",
        )
	
        result = conn.sql(
            "SELECT * FROM gen_function(?)",
            params=(count,),
        ).fetchall()
```

#### Example with Parameters=None

```py
import duckdb

conn = duckdb.connect()

conn.create_table_function(
    name="gen_function",
    callable=lambda x,count=10: [(f"name_{x}", i) for i in range(count)] ,
    parameters=None,
    schema=[["name", "VARCHAR"], ["id", "INT"]],
    type="tuples",
)

table = conn.execute("select * from gen_function('foo')").fetch_arrow_table()
table
```

#### Arrow Example

```py
import pyarrow as pa
import duckdb

conn = duckdb.connect()

def my_function(count=10):
    return pa.table({
        "id": list(range(count)),
        "value": [i * 2 for i in range(count)],
        "name": [f"row_{i}" for i in range(count)],
    })

conn.create_table_function(
    name="somefunction",
    callable=my_function,
    parameters=["count"],
    schema=[["id", "BIGINT"], ["value", "BIGINT"], ["name", "VARCHAR"]],
    type="arrow_table",
)

table = conn.execute("select * from somefunction(10)").df()
```

#### Discussion
##### Feature Name
What to call this feature?

Some databases refer to the function as Table Valued Functions, and others as User Defined Table Function. Either name works for me... I started with TVF but I think I'm not leaning towards UDTFs. 
- https://www.databricks.com/blog/introducing-python-user-defined-table-functions
- https://spark.apache.org/docs/latest/sql-ref-syntax-qry-select-tvf.html
- https://docs.snowflake.com/en/developer-guide/udf/sql/udf-sql-tabular-functions

##### Deleting / Unregistering
There doesn't appear to be a way to truly "delete" or "unregister" table functions from a connection... so does it make sense to even have an unregister? I chose to require an explicit unregister prior to registering a different function with same name, but this is somewhat arbitrary. 

##### Materializing vs Streaming the Iterator
I didn't notice any significant performance difference between streaming the iterator vs fully materializing it. The benefits outweighed the added complexity. 

There is perhaps some room for checking the callable result to see if it has a Length to set the Cardinality initially which may help the optimizer. 

##### Other Callable Types

This PR supports TUPLES and ARROW_TABLES. The TUPLE implementation supports streaming, but the ARROW_TABLES are fully materialized. 

ARROW_BATCHED_READER would make sense as a next type. I am assuming this is not required in an initial implementation. 