### PR TITLE
Fix Polars expr pushdown

### DIFF
--- a/duckdb/polars_io.py
+++ b/duckdb/polars_io.py
@@ -176,9 +176,14 @@ def _pl_tree_to_sql(tree: _ExpressionTree) -> str:
         if dtype.startswith("{'Decimal'") or dtype == "Decimal":
             decimal_value = value["Decimal"]
             assert isinstance(decimal_value, list), (
-                f"A {dtype} should be a two member list but got {type(decimal_value)}"
+                f"A {dtype} should be a two or three member list but got {type(decimal_value)}"
             )
-            return str(Decimal(decimal_value[0]) / Decimal(10 ** decimal_value[1]))
+            if len(decimal_value) == 2:  # pre-polars 1.34.0
+                return str(Decimal(decimal_value[0]) / Decimal(10 ** decimal_value[1]))
+            assert len(decimal_value) == 3, (  # since polars 1.34.0
+                f"A {dtype} should be a two or three member list but got {len(decimal_value)} member list"
+            )
+            return str(Decimal(decimal_value[0]) / Decimal(10 ** decimal_value[2]))
 
         # Datetime with microseconds since epoch
         if dtype.startswith("{'Datetime'") or dtype == "Datetime":

--- a/duckdb/polars_io.py
+++ b/duckdb/polars_io.py
@@ -179,7 +179,7 @@ def _pl_tree_to_sql(tree: _ExpressionTree) -> str:
             assert isinstance(decimal_value, list), (
                 f"A {dtype} should be a two or three member list but got {type(decimal_value)}"
             )
-            assert 2 >= len(decimal_value) <= 3, (
+            assert 2 <= len(decimal_value) <= 3, (
                 f"A {dtype} should be a two or three member list but got {len(decimal_value)} member list"
             )
             return str(Decimal(decimal_value[0]) / Decimal(10 ** decimal_value[-1]))

--- a/tests/fast/arrow/test_polars.py
+++ b/tests/fast/arrow/test_polars.py
@@ -1,4 +1,5 @@
 import datetime
+import json
 
 import pytest
 
@@ -8,7 +9,7 @@ pl = pytest.importorskip("polars")
 arrow = pytest.importorskip("pyarrow")
 pl_testing = pytest.importorskip("polars.testing")
 
-from duckdb.polars_io import _predicate_to_expression  # noqa: E402
+from duckdb.polars_io import _pl_tree_to_sql, _predicate_to_expression  # noqa: E402
 
 
 def valid_filter(filter):
@@ -605,3 +606,53 @@ class TestPolars:
         correct = duckdb_cursor.execute("FROM t").fetchall()
 
         assert res == correct
+
+    def test_invalid_expr_json(self):
+        bad_key_expr = """
+        {
+            "BinaryExpr": {
+                "left": { "Column": "foo" },
+                "middle": "Gt",
+                "right": { "Literal": { "Int": 5 } }
+            }
+        }
+        """
+        with pytest.raises(KeyError, match="'op'"):
+            _pl_tree_to_sql(json.loads(bad_key_expr))
+
+        bad_type_expr = """
+        {
+            "BinaryExpr": {
+                "left": { "Column": [ "foo" ]  },
+                "op": "Gt",
+                "right": { "Literal": { "Int": 5 } }
+            }
+        }
+        """
+        with pytest.raises(AssertionError, match="The col name of a Column should be a str but got"):
+            _pl_tree_to_sql(json.loads(bad_type_expr))
+
+    def test_old_dec(self):
+        bad_key_expr = """
+        {
+            "BinaryExpr": {
+                "left": { "Column": "foo" },
+                "middle": "Gt",
+                "right": { "Literal": { "Int": 5 } }
+            }
+        }
+        """
+        with pytest.raises(KeyError, match="'op'"):
+            _pl_tree_to_sql(json.loads(bad_key_expr))
+
+        bad_type_expr = """
+        {
+            "BinaryExpr": {
+                "left": { "Column": [ "foo" ]  },
+                "op": "Gt",
+                "right": { "Literal": { "Int": 5 } }
+            }
+        }
+        """
+        with pytest.raises(AssertionError, match="The col name of a Column should be a str but got"):
+            _pl_tree_to_sql(json.loads(bad_type_expr))

--- a/tests/fast/arrow/test_polars.py
+++ b/tests/fast/arrow/test_polars.py
@@ -175,7 +175,7 @@ class TestPolars:
             "UBIGINT",
             "FLOAT",
             "DOUBLE",
-            # "HUGEINT",
+            "HUGEINT",
             "DECIMAL(4,1)",
             "DECIMAL(9,1)",
             "DECIMAL(18,4)",

--- a/tests/fast/arrow/test_polars.py
+++ b/tests/fast/arrow/test_polars.py
@@ -632,27 +632,24 @@ class TestPolars:
         with pytest.raises(AssertionError, match="The col name of a Column should be a str but got"):
             _pl_tree_to_sql(json.loads(bad_type_expr))
 
-    def test_old_dec(self):
-        bad_key_expr = """
-        {
-            "BinaryExpr": {
-                "left": { "Column": "foo" },
-                "middle": "Gt",
-                "right": { "Literal": { "Int": 5 } }
-            }
-        }
+    def test_decimal_scale(self):
+        scalar_decimal_no_scale = """
+          { "Scalar": {
+            "Decimal": [
+              1,
+              0
+            ]
+          } }
         """
-        with pytest.raises(KeyError, match="'op'"):
-            _pl_tree_to_sql(json.loads(bad_key_expr))
+        assert _pl_tree_to_sql(json.loads(scalar_decimal_no_scale)) == "1"
 
-        bad_type_expr = """
-        {
-            "BinaryExpr": {
-                "left": { "Column": [ "foo" ]  },
-                "op": "Gt",
-                "right": { "Literal": { "Int": 5 } }
-            }
-        }
+        scalar_decimal_scale = """
+          { "Scalar": {
+            "Decimal": [
+              1,
+              38,
+              0
+            ]
+          } }
         """
-        with pytest.raises(AssertionError, match="The col name of a Column should be a str but got"):
-            _pl_tree_to_sql(json.loads(bad_type_expr))
+        assert _pl_tree_to_sql(json.loads(scalar_decimal_scale)) == "1"


### PR DESCRIPTION
See #98 

We have our own Polars IO plugin to create lazy polars dataframes. We try to push as many predicates down into DuckDB as we can, for which we try to map Polars expressions (including datatypes) to SQL expressions. To do this we depend on Polar's `Expr.meta.serialize`.

None of this is very stable. Polars IO source plugins are marked `@unstable` and `Expr.meta.serialize` says "Serialization is not stable across Polars versions".

In this case the problems seems to come from Polars requiring an explicit scale to be set for decimals ([this pr](https://github.com/pola-rs/polars/pull/24542)). The serialized format seems to have changed into:
```json
{
  "expr": {
    "Literal": {
      "Scalar": {
        "Decimal": [
          1,
          38, // This now includes the scale
          0
        ]
      }
    }
  },
  "dtype": {
    "Literal": {
      "Decimal": [
        38, // this was already there
        0
      ]
    }
  },
  "options": "Strict"
}

```

Interestingly, even if we explicitly set precision to e.g. 20, the relevant part of the serialized expression looks as follows:
```json
{
  "expr": {
    "Literal": {
      "Scalar": {
        "Decimal": [
          1,
          38, // Still 38?
          0
        ]
      }
    }
  },
  "dtype": {
    "Literal": {
      "Decimal": [
        20, // This is correct
        0
      ]
    }
  },
  "options": "Strict"
}
```

This PR allows for both a 2 and 3 item list for decimals.