### PR TITLE
Fix ADBC driver path resolution when `importlib.util` was not implicitly loaded 

### DIFF
--- a/adbc_driver_duckdb/__init__.py
+++ b/adbc_driver_duckdb/__init__.py
@@ -19,7 +19,7 @@
 
 import enum
 import functools
-import importlib
+import importlib.util
 import typing
 
 import adbc_driver_manager
@@ -46,5 +46,4 @@ def driver_path() -> str:
     if duckdb_module_spec is None:
         msg = "Could not find duckdb shared library. Did you pip install duckdb?"
         raise ImportError(msg)
-    print(f"Found duckdb shared library at {duckdb_module_spec.origin}")
     return duckdb_module_spec.origin


### PR DESCRIPTION
Fixes https://github.com/duckdb/duckdb-python/issues/134

Also removes a print statement when the driver is found.