### PR TITLE
Remove xfail annotations on adbc tests

### DIFF
--- a/tests/fast/adbc/test_adbc.py
+++ b/tests/fast/adbc/test_adbc.py
@@ -1,5 +1,4 @@
 import datetime
-import sys
 from pathlib import Path
 
 import adbc_driver_manager.dbapi
@@ -29,7 +28,6 @@ def example_table():
     )
 
 
-@xfail(sys.platform == "win32", reason="adbc-driver-manager.adbc_get_info() returns an empty dict on windows")
 def test_connection_get_info(duck_conn):
     assert duck_conn.adbc_get_info() != {}
 
@@ -42,9 +40,6 @@ def test_connection_get_table_types(duck_conn):
     assert duck_conn.adbc_get_table_types() == ["BASE TABLE"]
 
 
-@xfail(
-    sys.platform == "win32", reason="adbc-driver-manager.adbc_get_objects() returns an invalid schema dict on windows"
-)
 def test_connection_get_objects(duck_conn):
     with duck_conn.cursor() as cursor:
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
@@ -66,9 +61,6 @@ def test_connection_get_objects(duck_conn):
     assert depth_all.schema == depth_catalogs.schema
 
 
-@xfail(
-    sys.platform == "win32", reason="adbc-driver-manager.adbc_get_objects() returns an invalid schema dict on windows"
-)
 def test_connection_get_objects_filters(duck_conn):
     with duck_conn.cursor() as cursor:
         cursor.execute("CREATE TABLE getobjects (ints BIGINT PRIMARY KEY)")
@@ -207,7 +199,6 @@ def test_statement_query(duck_conn):
         assert cursor.fetch_arrow_table().to_pylist() == [{"foo": 1}]
 
 
-@xfail(sys.platform == "win32", reason="adbc-driver-manager returns an invalid table schema on windows")
 def test_insertion(duck_conn):
     table = example_table()
     reader = table.to_reader()
@@ -234,7 +225,6 @@ def test_insertion(duck_conn):
         assert cursor.fetch_arrow_table().to_pydict() == {"count_star()": [8]}
 
 
-@xfail(sys.platform == "win32", reason="adbc-driver-manager returns an invalid table schema on windows")
 def test_read(duck_conn):
     with duck_conn.cursor() as cursor:
         filename = Path(__file__).parent / ".." / "data" / "category.csv"


### PR DESCRIPTION
[#19444](https://github.com/duckdb/duckdb/pull/19444) fixed adbc issues on Windows, both in main and v1.4-andium. Confirmed that the tests pass in https://github.com/evertlammerts/duckdb-python/actions/runs/18946381716/job/54098707391, so we can remove the xfails.