### PR TITLE
spark imports

### DIFF
--- a/duckdb/__init__.py
+++ b/duckdb/__init__.py
@@ -201,6 +201,9 @@ from duckdb.value.constant import (
     Value,
 )
 
+# explicitly make the experimental module available
+from . import experimental
+
 __all__: list[str] = [
     "BinaryValue",
     "BinderException",
@@ -316,6 +319,7 @@ __all__: list[str] = [
     "enum_type",
     "execute",
     "executemany",
+    "experimental",
     "extract_statements",
     "fetch_arrow_table",
     "fetch_df",

--- a/duckdb/experimental/__init__.py
+++ b/duckdb/experimental/__init__.py
@@ -1,3 +1,5 @@
 from . import spark  # noqa: D104
 
-__all__ = spark.__all__
+__all__ = [
+    "spark",
+]


### PR DESCRIPTION
Make sure the experimental module is also exported in __all__ (might fix https://github.com/duckdb/duckdb/issues/17873)