### PR TITLE
Include duckdb distance in dev releases

### DIFF
--- a/.github/workflows/packaging_sdist.yml
+++ b/.github/workflows/packaging_sdist.yml
@@ -55,6 +55,13 @@ jobs:
         if: ${{ inputs.set-version != '' }}
         run: echo "OVERRIDE_GIT_DESCRIBE=${{ inputs.set-version }}" >> $GITHUB_ENV
 
+      - name: Set DUCKDB_DISTANCE
+        shell: bash
+        run: |
+          cd external/duckdb
+          DUCKDB_DISTANCE=$(git describe --tags --long | cut -d'-' -f2)
+          echo "DUCKDB_DISTANCE=$DUCKDB_DISTANCE" >> $GITHUB_ENV
+
       - name: Install Astral UV
         uses: astral-sh/setup-uv@v7
         with:

--- a/duckdb_packaging/setuptools_scm_version.py
+++ b/duckdb_packaging/setuptools_scm_version.py
@@ -72,15 +72,19 @@ def _bump_dev_version(base_version: str, distance: int) -> str:
         raise ValueError(msg)
     major, minor, patch, post, rc = parse_version(base_version)
 
+    # Get DuckDB submodule distance from its last tag (if set via env var)
+    duckdb_distance = os.getenv("DUCKDB_DISTANCE")
+    dev_suffix = f"{distance}.{duckdb_distance}" if duckdb_distance else str(distance)
+
     if post != 0:
         # We're developing on top of a post-release
-        return f"{format_version(major, minor, patch, post=post + 1)}.dev{distance}"
+        return f"{format_version(major, minor, patch, post=post + 1)}.dev{dev_suffix}"
     elif rc != 0:
         # We're developing on top of an rc
-        return f"{format_version(major, minor, patch, rc=rc + 1)}.dev{distance}"
+        return f"{format_version(major, minor, patch, rc=rc + 1)}.dev{dev_suffix}"
     elif _main_branch_versioning():
-        return f"{format_version(major, minor + 1, 0)}.dev{distance}"
-    return f"{format_version(major, minor, patch + 1)}.dev{distance}"
+        return f"{format_version(major, minor + 1, 0)}.dev{dev_suffix}"
+    return f"{format_version(major, minor, patch + 1)}.dev{dev_suffix}"
 
 
 def forced_version_from_env() -> str:

--- a/tests/fast/test_versioning.py
+++ b/tests/fast/test_versioning.py
@@ -121,6 +121,14 @@ class TestSetupToolsScmIntegration(unittest.TestCase):
         # Post-release development
         assert _bump_dev_version("1.2.3.post1", 3) == "1.2.3.post2.dev3"
 
+    @patch.dict("os.environ", {"MAIN_BRANCH_VERSIONING": "1", "DUCKDB_DISTANCE": "123"})
+    def test_bump_version_with_duckdb_distance(self):
+        """Test bump_version with DUCKDB_DISTANCE env var set."""
+        assert _bump_dev_version("1.2.3", 5) == "1.3.0.dev5.123"
+
+        # Post-release development
+        assert _bump_dev_version("1.2.3.post1", 3) == "1.2.3.post2.dev3.123"
+
     @patch.dict("os.environ", {"MAIN_BRANCH_VERSIONING": "0"})
     def test_bump_version_release_branch(self):
         """Test bump_version on bugfix branch."""


### PR DESCRIPTION
Right now nightlies only get published to PyPi when there are actual
python code changes, because the publishing script won't publish
packages with a version string that already exists in PyPi. Sometimes
changes only happen on the duckdb repo though, and not on duckdb-python.
This change includes the number of duckdb changes in the version number
too. That way whenever one of the two gets updated a new python package
is published.

Similar to #170
