### PR TITLE
Support Cast node in pushdown logic

### DIFF
--- a/duckdb/polars_io.py
+++ b/duckdb/polars_io.py
@@ -162,6 +162,9 @@ def _pl_tree_to_sql(tree: _ExpressionTree) -> str:
     if node_type == "Cast":
         cast_tree = tree[node_type]
         assert isinstance(cast_tree, dict), f"A {node_type} should be a dict but got {type(cast_tree)}"
+        if cast_tree.get("options") != "NonStrict":
+            msg = f"Only NonStrict casts can be safely unwrapped, got {cast_tree.get('options')!r}"
+            raise NotImplementedError(msg)
         cast_expr = cast_tree["expr"]
         assert isinstance(cast_expr, dict), f"A {node_type} should be a dict but got {type(cast_expr)}"
         return _pl_tree_to_sql(cast_expr)

--- a/tests/fast/arrow/test_polars.py
+++ b/tests/fast/arrow/test_polars.py
@@ -739,3 +739,9 @@ class TestPolars:
 
         assert lazy_df.filter(pl.col("a") == 1).collect().to_dicts() == [{"a": 1}]
         assert lazy_df.filter(pl.col("a") > 1).collect().to_dicts() == [{"a": 10}, {"a": 100}]
+
+    def test_explicit_cast_not_pushed_down(self):
+        """Explicit user .cast() (Strict) should not be pushed down - falls back to Polars."""
+        # pl.col("a").cast(pl.Int64) produces a Strict Cast node
+        expr = pl.col("a").cast(pl.Int64) > 5
+        invalid_filter(expr)


### PR DESCRIPTION
Related: #98 

When the decimal precision is anything other than 38, Polars wraps the expression in a Cast node. `_pl_tree_to_sql` didn't handle Cast nodes, causing silent pushdown failure. This fix makes sure these nodes get pushed down as well.

```
import duckdb
import polars as pl
import json

# Create a decimal column with precision != 38
con = duckdb.connect()
rel = con.sql("SELECT a::DECIMAL(20,0) AS a FROM range(10) AS t(a)")

lazy_df = rel.pl(lazy=True)

# This filter works but pushdown silently fails
result = lazy_df.filter(pl.col("a") == 1).collect()
print(f"Result: {len(result)} rows")  # Returns 1 row (correct)

# Polars serialized it as follows
expr = pl.col("a") == 1
tree = json.loads(expr.meta.serialize(format="json"))
print(json.dumps(tree, indent=2))
# Contains: "Cast": {"expr": ..., "dtype": {"Decimal": [20, 0]}, ...}
```

Note that we have to also check for the strictness of the cast node:
  - NonStrict casts are pushable, they are auto-inserted type coercion casts (like DECIMAL(20,0) to DECIMAL(38,0))
  - Strict casts are fallible (and can error, see https://github.com/pola-rs/polars/pull/22669)
