### PR TITLE
Throw a reasonable error when an array stream was already consumed

### DIFF
--- a/src/duckdb_py/arrow/arrow_array_stream.cpp
+++ b/src/duckdb_py/arrow/arrow_array_stream.cpp
@@ -71,7 +71,7 @@ unique_ptr<ArrowArrayStreamWrapper> PythonTableArrowArrayStreamFactory::Produce(
 		auto capsule = py::reinterpret_borrow<py::capsule>(arrow_obj_handle);
 		auto stream = capsule.get_pointer<struct ArrowArrayStream>();
 		if (!stream->release) {
-			throw InternalException("ArrowArrayStream was released by another thread/library");
+			throw InvalidInputException("This ArrowArrayStream has already been consumed and cannot be scanned again.");
 		}
 		res->arrow_array_stream = *stream;
 		stream->release = nullptr;
@@ -123,7 +123,7 @@ void PythonTableArrowArrayStreamFactory::GetSchemaInternal(py::handle arrow_obj_
 		auto capsule = py::reinterpret_borrow<py::capsule>(arrow_obj_handle);
 		auto stream = capsule.get_pointer<struct ArrowArrayStream>();
 		if (!stream->release) {
-			throw InternalException("ArrowArrayStream was released by another thread/library");
+			throw InvalidInputException("This ArrowArrayStream has already been consumed and cannot be scanned again.");
 		}
 		stream->get_schema(stream, &schema.arrow_schema);
 		return;


### PR DESCRIPTION
Related to #105

We shouldn't throw an InternalException when an Arrow stream was already consumed.