### PR TITLE
Treat empty params the same as None for .sql

### DIFF
--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -1600,8 +1600,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const py::object &quer
 
 	// Attempt to create a Relation for lazy execution if possible
 	shared_ptr<Relation> relation;
-	if (py::none().is(params)) {
-		// FIXME: currently we can't create relations with prepared parameters
+	bool has_params = !py::none().is(params) && py::len(params) > 0;
+	if (!has_params) {
+		// No params (or empty params) — use lazy QueryRelation path
 		{
 			D_ASSERT(py::gil_check());
 			py::gil_scoped_release gil;

--- a/tests/fast/api/test_sql_params_performance.py
+++ b/tests/fast/api/test_sql_params_performance.py
@@ -1,0 +1,40 @@
+import time
+
+
+class TestSqlEmptyParams:
+    """Empty params should use lazy QueryRelation path (same as params=None)."""
+
+    def test_empty_list_returns_same_result(self, duckdb_cursor):
+        """sql(params=[]) returns same data as sql(params=None)."""
+        duckdb_cursor.execute("CREATE TABLE t AS SELECT i FROM range(10) t(i)")
+        expected = duckdb_cursor.sql("SELECT * FROM t").fetchall()
+        result = duckdb_cursor.sql("SELECT * FROM t", params=[]).fetchall()
+        assert result == expected
+
+    def test_empty_dict_returns_same_result(self, duckdb_cursor):
+        """sql(params={}) returns same data as sql(params=None)."""
+        duckdb_cursor.execute("CREATE TABLE t AS SELECT i FROM range(10) t(i)")
+        expected = duckdb_cursor.sql("SELECT * FROM t").fetchall()
+        result = duckdb_cursor.sql("SELECT * FROM t", params={}).fetchall()
+        assert result == expected
+
+    def test_empty_tuple_returns_same_result(self, duckdb_cursor):
+        """sql(params=()) returns same data as sql(params=None)."""
+        duckdb_cursor.execute("CREATE TABLE t AS SELECT i FROM range(10) t(i)")
+        expected = duckdb_cursor.sql("SELECT * FROM t").fetchall()
+        result = duckdb_cursor.sql("SELECT * FROM t", params=()).fetchall()
+        assert result == expected
+
+    def test_empty_params_is_chainable(self, duckdb_cursor):
+        """Empty params produces a real relation that supports chaining."""
+        duckdb_cursor.execute("CREATE TABLE t AS SELECT i FROM range(10) t(i)")
+        result = duckdb_cursor.sql("SELECT * FROM t", params=[]).filter("i < 3").order("i").fetchall()
+        assert result == [(0,), (1,), (2,)]
+
+    def test_empty_params_explain_is_fast(self, duckdb_cursor):
+        """Empty params explain should not trigger expensive ToString."""
+        duckdb_cursor.execute("CREATE TABLE t AS SELECT i FROM range(100000) t(i)")
+        t0 = time.perf_counter()
+        duckdb_cursor.sql("SELECT * FROM t", params=[]).explain()
+        elapsed = time.perf_counter() - t0
+        assert elapsed < 5.0, f"explain() took {elapsed:.2f}s, expected < 5s"


### PR DESCRIPTION
Related to #238

This makes sure that passing in empty params results in a `QueryRelation` being created instead of a `MaterializedRelation`.

See [this comment](https://github.com/duckdb/duckdb-python/issues/238#issuecomment-3884098644) for more context.