### PR TITLE
Simplify GIL management for FetchRow

### DIFF
--- a/src/duckdb_py/pyresult.cpp
+++ b/src/duckdb_py/pyresult.cpp
@@ -117,16 +117,13 @@ unique_ptr<DataChunk> DuckDBPyResult::FetchNextRaw(QueryResult &query_result) {
 }
 
 Optional<py::tuple> DuckDBPyResult::Fetchone() {
-	{
-		D_ASSERT(py::gil_check());
+	if (!result) {
+		throw InvalidInputException("result closed");
+	}
+	if (!current_chunk || chunk_offset >= current_chunk->size()) {
 		py::gil_scoped_release release;
-		if (!result) {
-			throw InvalidInputException("result closed");
-		}
-		if (!current_chunk || chunk_offset >= current_chunk->size()) {
-			current_chunk = FetchNext(*result);
-			chunk_offset = 0;
-		}
+		current_chunk = FetchNext(*result);
+		chunk_offset = 0;
 	}
 
 	if (!current_chunk || current_chunk->size() == 0) {


### PR DESCRIPTION
Implements @paultiq's suggestion in #87 

We can save some overhead of GIL release by only releasing when we need to fetch a new chunk.