### PR TITLE
[codex] Use non-view registry for Python register

### DIFF
--- a/src/duckdb_py/include/duckdb_python/pyconnection/pyconnection.hpp
+++ b/src/duckdb_py/include/duckdb_python/pyconnection/pyconnection.hpp
@@ -169,7 +169,6 @@ public:
 	//! MemoryFileSystem used to temporarily store file-like objects for reading
 	shared_ptr<ModifiedMemoryFileSystem> internal_object_filesystem;
 	case_insensitive_map_t<unique_ptr<ExternalDependency>> registered_functions;
-	case_insensitive_set_t registered_objects;
 
 public:
 	explicit DuckDBPyConnection() {

--- a/src/duckdb_py/include/duckdb_python/python_replacement_scan.hpp
+++ b/src/duckdb_py/include/duckdb_python/python_replacement_scan.hpp
@@ -4,9 +4,24 @@
 #include "duckdb/common/case_insensitive_map.hpp"
 #include "duckdb/parser/tableref.hpp"
 #include "duckdb/function/replacement_scan.hpp"
+#include "duckdb_python/python_dependency.hpp"
 #include "duckdb_python/pybind11/pybind_wrapper.hpp"
 
 namespace duckdb {
+
+class PythonRegisteredObjectState : public ClientContextState {
+public:
+	static constexpr const char *Key = "python_registered_objects";
+
+	void Register(const string &name, const py::object &object);
+	void Unregister(const string &name);
+	py::object Get(const string &name);
+	bool Contains(const string &name);
+
+private:
+	mutex lock;
+	case_insensitive_map_t<shared_ptr<DependencyItem>> registered_objects;
+};
 
 struct PythonReplacementScan {
 public:

--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -1,5 +1,7 @@
 #include "duckdb_python/pyconnection/pyconnection.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/default/default_types.hpp"
 #include "duckdb/common/arrow/arrow.hpp"
 #include "duckdb/common/enums/profiler_format.hpp"
 #include "duckdb/common/types.hpp"
@@ -51,6 +53,17 @@ DBInstanceCache instance_cache;                                                 
 shared_ptr<PythonImportCache> DuckDBPyConnection::import_cache = nullptr;              // NOLINT: allow global
 PythonEnvironmentType DuckDBPyConnection::environment = PythonEnvironmentType::NORMAL; // NOLINT: allow global
 std::string DuckDBPyConnection::formatted_python_version = "";
+
+static shared_ptr<PythonRegisteredObjectState> GetPythonRegisteredObjectState(ClientContext &context) {
+	return context.registered_state->GetOrCreate<PythonRegisteredObjectState>(PythonRegisteredObjectState::Key);
+}
+
+static bool TemporaryObjectExists(ClientContext &context, const string &name) {
+	auto &catalog = Catalog::GetCatalog(context, TEMP_CATALOG);
+	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, name);
+	auto entry = catalog.GetEntry(context, DEFAULT_SCHEMA, lookup_info, OnEntryNotFound::RETURN_NULL);
+	return entry != nullptr;
+}
 
 DuckDBPyConnection::~DuckDBPyConnection() {
 	try {
@@ -743,11 +756,16 @@ shared_ptr<DuckDBPyConnection> DuckDBPyConnection::RegisterPythonObject(const st
                                                                         const py::object &python_object) {
 	auto &connection = con.GetConnection();
 	auto &client = *connection.context;
-	auto object = PythonReplacementScan::ReplacementObject(python_object, name, client);
-	auto view_rel = make_shared_ptr<ViewRelation>(connection.context, std::move(object), name);
-	bool replace = registered_objects.count(name);
-	view_rel->CreateView(name, replace, true);
-	registered_objects.insert(name);
+	auto registered_state = GetPythonRegisteredObjectState(client);
+	if (!registered_state->Contains(name)) {
+		bool temp_object_exists = false;
+		client.RunFunctionInTransaction([&]() { temp_object_exists = TemporaryObjectExists(client, name); }, false);
+		if (temp_object_exists) {
+			throw CatalogException("View with name \"%s\" already exists!", name);
+		}
+	}
+	PythonReplacementScan::ReplacementObject(python_object, name, client);
+	registered_state->Register(name, python_object);
 	return shared_from_this();
 }
 
@@ -1821,15 +1839,12 @@ unordered_set<string> DuckDBPyConnection::GetTableNames(const string &query, boo
 
 shared_ptr<DuckDBPyConnection> DuckDBPyConnection::UnregisterPythonObject(const string &name) {
 	auto &connection = con.GetConnection();
-	if (!registered_objects.count(name)) {
+	auto registered_state = GetPythonRegisteredObjectState(*connection.context);
+	if (!registered_state->Contains(name)) {
 		return shared_from_this();
 	}
 	D_ASSERT(py::gil_check());
-	py::gil_scoped_release release;
-	// FIXME: DROP TEMPORARY VIEW? doesn't exist?
-	const auto quoted_name = SQLQuotedIdentifier::ToString(name);
-	connection.Query("DROP VIEW " + quoted_name + "");
-	registered_objects.erase(name);
+	registered_state->Unregister(name);
 	return shared_from_this();
 }
 

--- a/src/duckdb_py/python_replacement_scan.cpp
+++ b/src/duckdb_py/python_replacement_scan.cpp
@@ -16,6 +16,34 @@
 
 namespace duckdb {
 
+void PythonRegisteredObjectState::Register(const string &name, const py::object &object) {
+	py::gil_scoped_acquire gil;
+	lock_guard<mutex> guard(lock);
+	registered_objects[name] = PythonDependencyItem::Create(object);
+}
+
+void PythonRegisteredObjectState::Unregister(const string &name) {
+	py::gil_scoped_acquire gil;
+	lock_guard<mutex> guard(lock);
+	registered_objects.erase(name);
+}
+
+py::object PythonRegisteredObjectState::Get(const string &name) {
+	py::gil_scoped_acquire gil;
+	lock_guard<mutex> guard(lock);
+	auto entry = registered_objects.find(name);
+	if (entry == registered_objects.end()) {
+		return py::none();
+	}
+	auto &dependency = entry->second->Cast<PythonDependencyItem>();
+	return dependency.object->obj;
+}
+
+bool PythonRegisteredObjectState::Contains(const string &name) {
+	lock_guard<mutex> guard(lock);
+	return registered_objects.find(name) != registered_objects.end();
+}
+
 static void CreateArrowScan(const string &name, py::object entry, TableFunctionRef &table_function,
                             vector<unique_ptr<ParsedExpression>> &children, ClientProperties &client_properties,
                             PyArrowObjectType type, DatabaseInstance &db) {
@@ -236,6 +264,16 @@ static unique_ptr<TableRef> ReplaceInternal(ClientContext &context, const string
 
 	if (!enabled) {
 		return nullptr;
+	}
+
+	auto registered_objects =
+	    context.registered_state->Get<PythonRegisteredObjectState>(PythonRegisteredObjectState::Key);
+	if (registered_objects) {
+		py::gil_scoped_acquire acquire;
+		auto entry = registered_objects->Get(table_name);
+		if (!entry.is_none()) {
+			return PythonReplacementScan::TryReplacementObject(entry, table_name, context);
+		}
 	}
 
 	lookup_result = context.TryGetCurrentSetting("python_scan_all_frames", result);

--- a/tests/fast/pandas/test_pandas_unregister.py
+++ b/tests/fast/pandas/test_pandas_unregister.py
@@ -1,5 +1,6 @@
 import gc
 import tempfile
+import weakref
 
 import pandas as pd
 import pytest
@@ -50,3 +51,20 @@ class TestPandasUnregister:
         with pytest.raises(duckdb.CatalogException, match="Table with name dataframe does not exist"):
             connection.execute("SELECT * FROM dataframe;").fetchdf()
         connection.close()
+
+    def test_pandas_unregister_releases_object_inside_transaction(self, duckdb_cursor):
+        duckdb_cursor.execute("CREATE TABLE t(i BIGINT)")
+        duckdb_cursor.begin()
+
+        df = pd.DataFrame({"i": [1, 2, 3]})
+        ref = weakref.ref(df)
+
+        duckdb_cursor.register("dataframe", df)
+        duckdb_cursor.execute("INSERT INTO t SELECT * FROM dataframe")
+        duckdb_cursor.unregister("dataframe")
+
+        del df
+        gc.collect()
+
+        assert ref() is None
+        duckdb_cursor.rollback()


### PR DESCRIPTION
## Summary

- replace the Python `register()` implementation with a connection-local registry resolved through replacement scans instead of creating a temporary view
- make `unregister()` erase the registered Python dependency immediately, including inside an open transaction
- keep existing temp object conflict behavior and add a pandas regression test that verifies the DataFrame can be collected after unregistering inside a transaction

## Root Cause

`register()` created a temporary view with an external dependency on the Python object. When `unregister()` ran inside a transaction, `DROP VIEW` did not release that dependency until the transaction completed, so large DataFrames stayed alive across the transaction.

## Validation

- `SKBUILD_EDITABLE_SKIP=/home/ubuntu/duckdb-sqlite-worktrees/duckdb-python-v1.5.3/build/debug python -m pytest tests/fast/pandas/test_pandas_unregister.py tests/fast/arrow/test_unregister.py tests/fast/api/test_duckdb_connection.py::TestDuckDBConnection::test_register_relation tests/fast/api/test_duckdb_connection.py::TestDuckDBConnection::test_unregister_problematic_behavior tests/fast/pandas/test_same_name.py::TestMultipleColumnsSameName::test_multiple_columns_with_same_name -q`
- manual weakref check: `unregister()` inside a transaction releases the DataFrame immediately and rollback does not resurrect the registered name
- full-size chunk sanity check: RSS growth still reproduces through the insert path without `register()`, while each registered DataFrame weakref is released after `unregister()`
