### PR TITLE
Fix numpy deprecation errors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -333,7 +333,7 @@ packages = ["duckdb", "_duckdb"]
 strict = true
 warn_unreachable = true
 pretty = true
-python_version = "3.10"
+python_version = "3.12"
 exclude = [
     "duckdb/experimental/", # not checking the pyspark API
     "duckdb/query_graph/",  # old and unmaintained (should probably remove)

--- a/tests/fast/test_all_types.py
+++ b/tests/fast/test_all_types.py
@@ -387,7 +387,7 @@ class TestAllTypes:
             # such that the conversion yields "Not a Time"
             "timestamp_ns": np.ma.array(
                 [
-                    np.datetime64("NaT"),
+                    np.datetime64("NaT", "ns"),
                     np.datetime64(9223372036854775806, "ns"),
                     np.datetime64("1990-01-01T00:42"),
                 ],

--- a/tests/fast/test_all_types.py
+++ b/tests/fast/test_all_types.py
@@ -377,9 +377,9 @@ class TestAllTypes:
             ),
             "interval": np.ma.array(
                 [
-                    np.timedelta64(0),
-                    np.timedelta64(2675722599999999000),
-                    np.timedelta64(42),
+                    np.timedelta64(0, "ns"),
+                    np.timedelta64(2675722599999999000, "ns"),
+                    np.timedelta64(42, "ns"),
                 ],
                 mask=[0, 0, 1],
             ),


### PR DESCRIPTION
Fixes:
```
DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.
```