### PR TITLE
Fixup timedelta64 to be `us`

### DIFF
--- a/tests/fast/test_all_types.py
+++ b/tests/fast/test_all_types.py
@@ -377,9 +377,9 @@ class TestAllTypes:
             ),
             "interval": np.ma.array(
                 [
-                    np.timedelta64(0),
-                    np.timedelta64(2675722599999999000),
-                    np.timedelta64(42),
+                    np.timedelta64(0, "us"),
+                    np.timedelta64(2675722599999999000, "us"),
+                    np.timedelta64(42, "us"),
                 ],
                 mask=[0, 0, 1],
             ),


### PR DESCRIPTION
Trying to solve CI-reported issues like:
> DeprecationWarning: The 'generic' unit for NumPy timedelta is deprecated, and will raise an error in the future. This includes implicit conversion of bare integers (e.g. `+ 1`).Please use a specific unit instead.