### PR TITLE
Drop pybind11 module_local() from bound-type registrations

### DIFF
--- a/src/duckdb_py/duckdb_python.cpp
+++ b/src/duckdb_py/duckdb_python.cpp
@@ -1106,7 +1106,7 @@ PYBIND11_MODULE(DUCKDB_PYTHON_LIB_NAME, m) { // NOLINT
 	      "Tokenizes a SQL string, returning a list of (position, type) tuples that can be "
 	      "used for e.g., syntax highlighting",
 	      py::arg("query"));
-	py::enum_<PySQLTokenType>(m, "token_type", py::module_local())
+	py::enum_<PySQLTokenType>(m, "token_type")
 	    .value("identifier", PySQLTokenType::PY_SQL_TOKEN_IDENTIFIER)
 	    .value("numeric_const", PySQLTokenType::PY_SQL_TOKEN_NUMERIC_CONSTANT)
 	    .value("string_const", PySQLTokenType::PY_SQL_TOKEN_STRING_CONSTANT)

--- a/src/duckdb_py/pyconnection.cpp
+++ b/src/duckdb_py/pyconnection.cpp
@@ -454,8 +454,8 @@ DuckDBPyConnection::RegisterScalarUDF(const string &name, const py::function &ud
 }
 
 void DuckDBPyConnection::Initialize(py::handle &m) {
-	auto connection_module = py::class_<DuckDBPyConnection, std::shared_ptr<DuckDBPyConnection>>(
-	    m, "DuckDBPyConnection", py::module_local());
+	auto connection_module =
+	    py::class_<DuckDBPyConnection, std::shared_ptr<DuckDBPyConnection>>(m, "DuckDBPyConnection");
 
 	connection_module.def("__enter__", &DuckDBPyConnection::Enter)
 	    .def("__exit__", &DuckDBPyConnection::Exit, py::arg("exc_type"), py::arg("exc"), py::arg("traceback"));

--- a/src/duckdb_py/pyexpression/initialize.cpp
+++ b/src/duckdb_py/pyexpression/initialize.cpp
@@ -301,8 +301,7 @@ static void InitializeImplicitConversion(py::class_<DuckDBPyExpression, std::sha
 }
 
 void DuckDBPyExpression::Initialize(py::module_ &m) {
-	auto expression =
-	    py::class_<DuckDBPyExpression, std::shared_ptr<DuckDBPyExpression>>(m, "Expression", py::module_local());
+	auto expression = py::class_<DuckDBPyExpression, std::shared_ptr<DuckDBPyExpression>>(m, "Expression");
 
 	InitializeStaticMethods(m);
 	InitializeDunderMethods(expression);

--- a/src/duckdb_py/pyrelation/initialize.cpp
+++ b/src/duckdb_py/pyrelation/initialize.cpp
@@ -274,7 +274,7 @@ static void InitializeMetaQueries(py::class_<DuckDBPyRelation> &m) {
 }
 
 void DuckDBPyRelation::Initialize(py::handle &m) {
-	auto relation_module = py::class_<DuckDBPyRelation>(m, "DuckDBPyRelation", py::module_local());
+	auto relation_module = py::class_<DuckDBPyRelation>(m, "DuckDBPyRelation");
 	InitializeReadOnlyProperties(relation_module);
 	InitializeAggregates(relation_module);
 	InitializeWindowOperators(relation_module);

--- a/src/duckdb_py/pystatement.cpp
+++ b/src/duckdb_py/pystatement.cpp
@@ -15,8 +15,7 @@ static void InitializeReadOnlyProperties(py::class_<DuckDBPyStatement, std::uniq
 }
 
 void DuckDBPyStatement::Initialize(py::handle &m) {
-	auto relation_module =
-	    py::class_<DuckDBPyStatement, std::unique_ptr<DuckDBPyStatement>>(m, "Statement", py::module_local());
+	auto relation_module = py::class_<DuckDBPyStatement, std::unique_ptr<DuckDBPyStatement>>(m, "Statement");
 	InitializeReadOnlyProperties(relation_module);
 }
 

--- a/src/duckdb_py/typing/pytype.cpp
+++ b/src/duckdb_py/typing/pytype.cpp
@@ -327,7 +327,7 @@ static LogicalType FromObject(const py::object &object) {
 }
 
 void DuckDBPyType::Initialize(py::handle &m) {
-	auto type_module = py::class_<DuckDBPyType, std::shared_ptr<DuckDBPyType>>(m, "DuckDBPyType", py::module_local());
+	auto type_module = py::class_<DuckDBPyType, std::shared_ptr<DuckDBPyType>>(m, "DuckDBPyType");
 
 	type_module.def("__repr__", &DuckDBPyType::ToString, "Stringified representation of the type object");
 	type_module.def("__eq__", &DuckDBPyType::Equals, "Compare two types for equality", py::arg("other"),


### PR DESCRIPTION
Remove the 6 py::module_local() annotations (DuckDBPyConnection, Statement, Expression, Relation, Type class_ registrations + the token_type enum).