### PR TITLE
Fix alias of `DuckDBPyRelation.query` (closes #468)

### DIFF
--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -1550,8 +1550,9 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, co
 	auto &statement = *parser.statements[0];
 	if (statement.type == StatementType::SELECT_STATEMENT) {
 		auto select_statement = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
-		auto query_relation = make_shared_ptr<QueryRelation>(rel->context->GetContext(), std::move(select_statement),
-		                                                     "query_relation_" + StringUtil::GenerateRandomName(16), sql_query);
+		auto query_relation =
+		    make_shared_ptr<QueryRelation>(rel->context->GetContext(), std::move(select_statement),
+		                                   "query_relation_" + StringUtil::GenerateRandomName(16), sql_query);
 		return DeriveRelation(std::move(query_relation));
 	} else if (IsDescribeStatement(statement)) {
 		auto query = PragmaShow(view_name);

--- a/src/duckdb_py/pyrelation.cpp
+++ b/src/duckdb_py/pyrelation.cpp
@@ -1551,7 +1551,7 @@ unique_ptr<DuckDBPyRelation> DuckDBPyRelation::Query(const string &view_name, co
 	if (statement.type == StatementType::SELECT_STATEMENT) {
 		auto select_statement = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
 		auto query_relation = make_shared_ptr<QueryRelation>(rel->context->GetContext(), std::move(select_statement),
-		                                                     sql_query, "query_relation");
+		                                                     "query_relation_" + StringUtil::GenerateRandomName(16), sql_query);
 		return DeriveRelation(std::move(query_relation));
 	} else if (IsDescribeStatement(statement)) {
 		auto query = PragmaShow(view_name);

--- a/tests/fast/relational_api/test_rapi_query.py
+++ b/tests/fast/relational_api/test_rapi_query.py
@@ -38,6 +38,19 @@ class TestRAPIQuery:
         result = rel.execute()
         assert len(result.fetchall()) == amount
 
+    def test_query_chain_using_alias(self):
+        # Test query chaining using DuckDBPyRelation.alias
+        con = duckdb.connect()
+        con.execute("CREATE TABLE raw (yr INT, facility VARCHAR, val DOUBLE)")
+        con.execute("INSERT INTO raw VALUES (2020, 'F001', 1.0), (2021, 'F001', 2.0)")
+        data = con.sql("SELECT * FROM raw")
+        step1 = data.query(data.alias, f"SELECT *, val * 2 AS val_doubled FROM {data.alias}")
+        step2 = step1.query(step1.alias, f"SELECT *, val_doubled + 1 AS val_incremented FROM {step1.alias}")
+        assert step2.fetchall() == [
+            (2020, "F001", 1.0, 2.0, 3.0),
+            (2021, "F001", 2.0, 4.0, 5.0),
+        ]
+
     @pytest.mark.parametrize("input", [[5, 4, 3], [], [1000]])
     def test_query_table(self, tbl_table, input):
         con = duckdb.default_connection()


### PR DESCRIPTION
Re-lands leostimpfle's fix from #521 cleanly on v1.5-variegata (the original PR accidentally merged main). Authored by
  @leostimpfle.