### PR TITLE
fix: include catalog.hpp directly in pyconnection.cpp

### DIFF
--- a/src/pyconnection.cpp
+++ b/src/pyconnection.cpp
@@ -1,5 +1,6 @@
 #include "duckdb_python/pyconnection/pyconnection.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/common/arrow/arrow.hpp"
 #include "duckdb/common/types.hpp"
 #include "duckdb/common/types/vector.hpp"


### PR DESCRIPTION
## What

One-line fix: add `#include "duckdb/catalog/catalog.hpp"` to `src/pyconnection.cpp`.

## Why

`pyconnection.cpp` uses `Catalog::GetCatalog` / `Catalog::GetSystemCatalog` but relied on a transitive include of `catalog.hpp` via `function/table_function.hpp` → `execution/physical_operator_states.hpp`. duckdb main removed that include chain (~2026-07-10).

PR and nightly CI build against duckdb main (`duckdb-sha: ${{ github.base_ref }}` in `on_pr.yml`), so every PR currently fails with:

```
src/pyconnection.cpp:447:19: error: incomplete type 'duckdb::Catalog' named in nested name specifier
```

(e.g. #409 and main's own Release runs). Builds against the pinned submodule (3a3c412) are unaffected, which is why this doesn't reproduce locally.

## Verification

Compiled `pyconnection.cpp` locally against both duckdb main (2009475939) and the pinned submodule: error reproduces on duckdb main without this change, compiles cleanly with it on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)