### PR TITLE
fix: unbreak CI — pyarrow 25 added binary_view compare kernels, tripping the strict-xfail canary

### DIFF
--- a/tests/fast/arrow/test_filter_pushdown.py
+++ b/tests/fast/arrow/test_filter_pushdown.py
@@ -754,28 +754,40 @@ class TestCanaries:
 
     @pytest.mark.xfail(
         raises=pa_lib.ArrowNotImplementedError,
-        reason="pyarrow does not yet implement string_view filter compare kernels",
+        reason="pyarrow does not yet implement string_view filter kernels",
         strict=True,
     )
     def test_pyarrow_gains_string_view_filter_support(self):
-        """When pyarrow adds string_view comparison kernels this will xpass.
+        """When pyarrow can execute a string_view filter end-to-end this will xpass.
 
         At that point we should remove the post-scan fallback in TestUnsupportedTypes.
+        Today the scanner cannot even be constructed ('equal' has no string_view
+        kernel); executing it is included so this canary only fires on full support
+        (see the binary_view canary below for how compare kernels can land first).
         """
         filter_expr = pa_ds.field("col") == pa_ds.scalar("val1")
         table = pa.table({"col": pa.array(["val1", "val2"], type=pa.string_view())})
-        pa_ds.dataset(table).scanner(columns=["col"], filter=filter_expr)
+        pa_ds.dataset(table).scanner(columns=["col"], filter=filter_expr).to_table()
 
-    @pytest.mark.xfail(
-        raises=pa_lib.ArrowNotImplementedError,
-        reason="pyarrow does not yet implement binary_view filter compare kernels",
-        strict=True,
-    )
     def test_pyarrow_gains_binary_view_filter_support(self):
-        """When pyarrow adds binary_view comparison kernels this will xpass."""
+        """Canary tracking pyarrow's binary_view filter support.
+
+        pyarrow 25.0.0 added binary_view compare kernels, so constructing a
+        scanner with a binary_view filter now succeeds. Executing the scan still
+        raises: 'array_filter' has no binary_view kernel. Once execution works
+        too, this test fails and we should remove the post-scan fallback in
+        TestUnsupportedTypes.
+        """
         filter_expr = pa_ds.field("col") == pa_ds.scalar(pa.scalar(b"bin1", pa.binary_view()))
         table = pa.table({"col": pa.array([b"bin1", b"bin2"], type=pa.binary_view())})
-        pa_ds.dataset(table).scanner(columns=["col"], filter=filter_expr)
+        if Version(pa.__version__) < Version("25.0.0"):
+            # No binary_view compare kernels: the scanner cannot even be constructed.
+            with pytest.raises(pa_lib.ArrowNotImplementedError, match="binary_view"):
+                pa_ds.dataset(table).scanner(columns=["col"], filter=filter_expr)
+        else:
+            scanner = pa_ds.dataset(table).scanner(columns=["col"], filter=filter_expr)
+            with pytest.raises(pa_lib.ArrowNotImplementedError, match="binary_view"):
+                scanner.to_table()
 
     # ----- DuckDB optimizer decisions we expect to change --------------
 


### PR DESCRIPTION
## Problem

Every PR's CI currently fails with:

```
FAILED tests/fast/arrow/test_filter_pushdown.py::TestCanaries::test_pyarrow_gains_binary_view_filter_support - [XPASS(strict)] pyarrow does not yet implement binary_view filter compare kernels
```

(example run: https://github.com/duckdb/duckdb-python/actions/runs/29216913610, from #409 — unrelated to that PR's content)

CI installs the *latest* pyarrow at run time, and **pyarrow 25.0.0** added `binary_view` compare kernels. The canary body only exercised **scanner construction**, which no longer raises, so the strict xfail XPASSes and fails CI for everyone. Same spirit as #541: unbreak CI on main.

## What actually changed in pyarrow (verified empirically on 23.0.1, 24.0.0, 25.0.0)

| pyarrow | `scanner(filter=binary_view ==)` | executing the scan |
|---|---|---|
| ≤ 24.0.0 | raises `ArrowNotImplementedError` (`'equal'` has no binary_view kernel) | n/a |
| 25.0.0 | **succeeds** | raises `ArrowNotImplementedError` (`'array_filter'` has no binary_view kernel) |

So pyarrow's support is still only **partial** — a binary_view filter still cannot be executed end-to-end, and DuckDB's post-scan fallback for view types (covered by `TestUnsupportedTypes`) is still required. (`string_view` is unchanged: even scanner construction still raises on 25.0.0.)

## Fix

* `test_pyarrow_gains_binary_view_filter_support` is converted from a strict xfail into a version-gated assertion (using the file's existing `packaging.version.Version` convention):
  * **pyarrow < 25**: scanner construction must raise `ArrowNotImplementedError`
  * **pyarrow ≥ 25**: scanner construction must succeed, and executing the scan must raise `ArrowNotImplementedError`

  Either branch failing means pyarrow moved again, preserving the canary's purpose: it fires when pyarrow gains full binary_view filter support and the post-scan fallback should be removed.
* The sibling `string_view` canary keeps its strict xfail but now also **executes** the scanner, so when pyarrow lands string_view compare kernels ahead of filter kernels (as just happened for binary_view), it will keep xfailing instead of breaking CI again; it only xpasses on full end-to-end support.

## Verification

* Full `tests/fast/arrow/test_filter_pushdown.py` with pyarrow 23.0.1 (the repo's minimum for Python ≥ 3.10): 541 passed, 7 xfailed.
* `TestCanaries` + `TestUnsupportedTypes` with pyarrow 25.0.0: 10 passed, 7 xfailed — the view-type post-scan fallback still yields correct results on latest pyarrow.
* `ruff check` / `ruff format --check` clean.

Judgment call: rather than simply widening the xfail, the ≥ 25 branch pins down the new partial-support behaviour (construction works, execution doesn't), which documents exactly where pyarrow stands and what the fallback still protects against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)