### PR TITLE
Fixes to Spark API show() and udf.register()

### DIFF
--- a/duckdb/experimental/spark/sql/dataframe.py
+++ b/duckdb/experimental/spark/sql/dataframe.py
@@ -38,8 +38,27 @@ class DataFrame:  # noqa: D101
         if self.relation is not None:
             self._schema = duckdb_to_spark_schema(self.relation.columns, self.relation.types)
 
-    def show(self, **kwargs) -> None:  # noqa: D102
-        self.relation.show()
+    def show(
+        self,
+        n: int = 20,
+        truncate: Union[bool, int] = True,
+        vertical: bool = False,
+        **kwargs,
+    ) -> None:  # noqa: D102
+        if isinstance(truncate, int):
+            max_col_width = truncate
+        elif truncate:
+            max_col_width = 20
+        else:
+            max_col_width = 9999
+
+        render_mode = 'COLUMNS' if vertical else None
+
+        self.relation.show(
+            max_rows=n,
+            max_col_width=max_col_width,
+            render_mode=render_mode
+        )
 
     def toPandas(self) -> "PandasDataFrame":  # noqa: D102
         return self.relation.df()

--- a/duckdb/experimental/spark/sql/dataframe.py
+++ b/duckdb/experimental/spark/sql/dataframe.py
@@ -43,7 +43,6 @@ class DataFrame:  # noqa: D101
         n: int = 20,
         truncate: Union[bool, int] = True,
         vertical: bool = False,
-        **kwargs,
     ) -> None:  # noqa: D102
         if isinstance(truncate, int):
             max_col_width = truncate

--- a/duckdb/experimental/spark/sql/udf.py
+++ b/duckdb/experimental/spark/sql/udf.py
@@ -23,7 +23,8 @@ class UDFRegistration:  # noqa: D101
         f: "Callable[..., Any] | UserDefinedFunctionLike",
         returnType: Optional["DataTypeOrString"] = None,
     ) -> "UserDefinedFunctionLike":
-        self.sparkSession.conn.create_function(name, f, return_type=returnType)
+        self.sparkSession.conn.create_function(name, f, None,
+                                               return_type=returnType.duckdb_type)
 
     def registerJavaFunction(  # noqa: D102
         self,

--- a/duckdb/experimental/spark/sql/udf.py
+++ b/duckdb/experimental/spark/sql/udf.py
@@ -27,7 +27,7 @@ class UDFRegistration:  # noqa: D101
             name,
             f,
             None,
-            return_type=returnType.duckdb_type,
+            return_type=returnType.duckdb_type if returnType else None,
             null_handling='special',  # PySpark UDFs handle nulls
         )
 

--- a/duckdb/experimental/spark/sql/udf.py
+++ b/duckdb/experimental/spark/sql/udf.py
@@ -23,8 +23,13 @@ class UDFRegistration:  # noqa: D101
         f: "Callable[..., Any] | UserDefinedFunctionLike",
         returnType: Optional["DataTypeOrString"] = None,
     ) -> "UserDefinedFunctionLike":
-        self.sparkSession.conn.create_function(name, f, None,
-                                               return_type=returnType.duckdb_type)
+        self.sparkSession.conn.create_function(
+            name,
+            f,
+            None,
+            return_type=returnType.duckdb_type,
+            null_handling='special',
+        )
 
     def registerJavaFunction(  # noqa: D102
         self,

--- a/duckdb/experimental/spark/sql/udf.py
+++ b/duckdb/experimental/spark/sql/udf.py
@@ -28,7 +28,7 @@ class UDFRegistration:  # noqa: D101
             f,
             None,
             return_type=returnType.duckdb_type,
-            null_handling='special',
+            null_handling='special',  # PySpark UDFs handle nulls
         )
 
     def registerJavaFunction(  # noqa: D102


### PR DESCRIPTION
Match signature to Spark API's show() method to PySpark's and translate parameters to DuckDB's show().

Fix call to create_function() in Spark API's UDFRegistration.register(). It lacked the correct third argument (input parameters, set to None). It assumes a PySpark style return type parameter (eg T.StringType()) and translates it to the DuckDB SQL type for the create_function() call. Sets null_handling='special' to match PySpark UDF behavior.