### PR TITLE
Fix and conform Spark API's show() and UDF register().

### DIFF
--- a/duckdb/experimental/spark/sql/dataframe.py
+++ b/duckdb/experimental/spark/sql/dataframe.py
@@ -38,8 +38,26 @@ class DataFrame:  # noqa: D101
         if self.relation is not None:
             self._schema = duckdb_to_spark_schema(self.relation.columns, self.relation.types)
 
-    def show(self, **kwargs) -> None:  # noqa: D102
-        self.relation.show()
+    def show(
+        self,
+        n: int = 20,
+        truncate: Union[bool, int] = True,
+        vertical: bool = False,
+    ) -> None:  # noqa: D102
+        if isinstance(truncate, int):
+            max_col_width = truncate
+        elif truncate:
+            max_col_width = 20
+        else:
+            max_col_width = 9999
+
+        render_mode = 'COLUMNS' if vertical else None
+
+        self.relation.show(
+            max_rows=n,
+            max_col_width=max_col_width,
+            render_mode=render_mode
+        )
 
     def toPandas(self) -> "PandasDataFrame":  # noqa: D102
         return self.relation.df()

--- a/duckdb/experimental/spark/sql/udf.py
+++ b/duckdb/experimental/spark/sql/udf.py
@@ -23,7 +23,13 @@ class UDFRegistration:  # noqa: D101
         f: "Callable[..., Any] | UserDefinedFunctionLike",
         returnType: Optional["DataTypeOrString"] = None,
     ) -> "UserDefinedFunctionLike":
-        self.sparkSession.conn.create_function(name, f, return_type=returnType)
+        self.sparkSession.conn.create_function(
+            name,
+            f,
+            None,
+            return_type=returnType.duckdb_type if returnType else None,
+            null_handling='special',
+        )
 
     def registerJavaFunction(  # noqa: D102
         self,


### PR DESCRIPTION
Match DataFrame.show() signature with PySpark's.
Translate show() arguments to those of DuckDBPyRelation's show().
Add third argument to create_function() call in register().
Assume register() takes Spark API return type argument.
Add null_handling argument to match PySpark's behavior.