### PR TITLE
Record python client release state at end of workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -236,3 +236,15 @@ jobs:
           echo "* Vendored DuckDB Version: ${{ needs.build_sdist.outputs.duckdb-version }} (${dsha:0:10})" >> $GITHUB_STEP_SUMMARY
           echo "* S3 upload status: ${{ needs.upload_s3.result == 'success' && needs.workflow_state.outputs.s3_url || needs.upload_s3.result }}" >> $GITHUB_STEP_SUMMARY
           echo "* CI Environment: ${{ needs.workflow_state.outputs.ci_env }}" >> $GITHUB_STEP_SUMMARY
+
+      - name: Record client status
+        if: ${{ github.repository_owner == 'duckdb' }}
+        uses: duckdb/duckdb-workflow-trigger/dispatch@main
+        with:
+          github_token: ${{ secrets.PAT_TOKEN }}
+          event: client_ready
+          client: python
+          duckdb_version: ${{ needs.build_sdist.outputs.duckdb-version }}
+          duckdb_commit: ${{ inputs.duckdb-sha }}
+          status: ${{ contains(needs.*.result, 'failure') && 'failure' || contains(needs.*.result, 'cancelled') && 'cancelled' || 'success' }}
+          message: DuckDB Python client ready


### PR DESCRIPTION
This PR is part of the [alpha](https://github.com/duckdblabs/duckdb-internal/issues/8628) release versions initiative.

The added action sends the release state of the python client back to the [release event system](https://github.com/duckdblabs/duckdb-internal/issues/9742).

See also the release event system [usage](https://github.com/duckdb/duckdb-workflow-trigger/#usage).