### PR TITLE
Use offset with length for statement query

### DIFF
--- a/src/pystatement.cpp
+++ b/src/pystatement.cpp
@@ -29,8 +29,7 @@ unique_ptr<SQLStatement> DuckDBPyStatement::GetStatement() {
 
 string DuckDBPyStatement::Query() const {
 	auto &loc = statement->stmt_location;
-	auto &length = statement->stmt_length;
-	return statement->query.substr(loc, length);
+	return statement->query.substr(loc.offset, loc.length);
 }
 
 nb::set DuckDBPyStatement::NamedParameters() const {


### PR DESCRIPTION
CI job release [fails](https://github.com/duckdb/duckdb-python/actions/runs/30421972678/job/90480500097#step:7:2680) in `Install sdist` on `main` with:

```c++
In member function ‘std::string duckdb::DuckDBPyStatement::Query() const’: src/pystatement.cpp:32:35:
error: ‘class duckdb::SQLStatement’ has no member named ‘stmt_length’
     32 |         auto &length = statement->stmt_length;
        |                                   ^~~~~~~~~~~
```