### PR TITLE
Use QueryLocation and GetParameterCount

### DIFF
--- a/src/pyconnection.cpp
+++ b/src/pyconnection.cpp
@@ -618,13 +618,13 @@ identifier_map_t<BoundParameterData> TransformPreparedParameters(ClientContext &
                                                                  optional_ptr<PreparedStatement> prep = {}) {
 	identifier_map_t<BoundParameterData> named_values;
 	if (duckdb::PyUtil::IsListLike(params)) {
-		if (prep && prep->named_param_map.size() != nb::len(params)) {
+		if (prep && prep->GetParameterCount() != nb::len(params)) {
 			if (nb::len(params) == 0) {
 				throw InvalidInputException("Expected %d parameters, but none were supplied",
-				                            prep->named_param_map.size());
+				                            prep->GetParameterCount());
 			}
-			throw InvalidInputException("Prepared statement needs %d parameters, %d given",
-			                            prep->named_param_map.size(), nb::len(params));
+			throw InvalidInputException("Prepared statement needs %d parameters, %d given", prep->GetParameterCount(),
+			                            nb::len(params));
 		}
 		auto unnamed_values = DuckDBPyConnection::TransformPythonParamList(context, params);
 		for (idx_t i = 0; i < unnamed_values.size(); i++) {

--- a/src/pystatement.cpp
+++ b/src/pystatement.cpp
@@ -29,8 +29,7 @@ unique_ptr<SQLStatement> DuckDBPyStatement::GetStatement() {
 
 string DuckDBPyStatement::Query() const {
 	auto &loc = statement->stmt_location;
-	auto &length = statement->stmt_length;
-	return statement->query.substr(loc, length);
+	return statement->query.substr(loc.offset, loc.length);
 }
 
 nb::set DuckDBPyStatement::NamedParameters() const {


### PR DESCRIPTION
Fixes latest build issues introduced by duckdb/duckdb#24159 and duckdb/duckdb#24273.

Note that duckdb core's debug build is broken again due to missing imports.

Supersedes #573 