### PR TITLE
fix(typing): read_json's stub only allowed a single path, not a list

### DIFF
--- a/_duckdb-stubs/__init__.pyi
+++ b/_duckdb-stubs/__init__.pyi
@@ -404,7 +404,14 @@ class DuckDBPyConnection:
     ) -> DuckDBPyRelation: ...
     def read_json(
         self,
-        path_or_buffer: str | bytes | os.PathLike[str] | os.PathLike[bytes] | typing.IO[bytes] | typing.IO[str],
+        # stubgen override: read_json accepts a list of paths at runtime, not just a single one (#576)
+        path_or_buffer: str
+        | bytes
+        | os.PathLike[str]
+        | os.PathLike[bytes]
+        | typing.IO[bytes]
+        | typing.IO[str]
+        | Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes] | typing.IO[bytes] | typing.IO[str]],
         *,
         columns: ColumnsTypes | None = None,
         sample_size: int | None = None,
@@ -1191,7 +1198,14 @@ def read_csv(
     strict_mode: bool | None = None,
 ) -> DuckDBPyRelation: ...
 def read_json(
-    path_or_buffer: str | bytes | os.PathLike[str] | os.PathLike[bytes] | typing.IO[bytes] | typing.IO[str],
+    # stubgen override: read_json accepts a list of paths at runtime, not just a single one (#576)
+    path_or_buffer: str
+    | bytes
+    | os.PathLike[str]
+    | os.PathLike[bytes]
+    | typing.IO[bytes]
+    | typing.IO[str]
+    | Sequence[str | bytes | os.PathLike[str] | os.PathLike[bytes] | typing.IO[bytes] | typing.IO[str]],
     *,
     columns: ColumnsTypes | None = None,
     sample_size: int | None = None,


### PR DESCRIPTION
## Summary

Fixes #576.

`read_json` accepts a list of paths at runtime (reading multiple newline-delimited JSON files as one relation), but the type stub only listed a single `str | bytes | PathLike | IO`. mypy and pyright both reject valid calls like:

```python
con.read_json(["a.jsonl", "b.jsonl"], format="newline_delimited")
```

## Fix

Widened `path_or_buffer` on `read_json` to also accept a `Sequence` of the same union, matching the exact pattern `from_parquet` / `read_parquet` / `from_csv_auto` already use in this same file. Applied to both the `DuckDBPyConnection.read_json` method stub and the module-level `read_json` wrapper stub, since both currently disagree with the runtime the same way.

Kept the diff minimal, on purpose: I noticed `_duckdb-stubs/__init__.pyi` has some pre-existing ruff findings (a few `PYI021` docstrings, one `PYI002`) unrelated to this change, and deliberately left those alone rather than folding an unrelated cleanup into a typing bugfix PR.

## Verification

Reproduced the exact snippet from #576 against the fixed stub:

- `mypy --strict`: reports the argument-type error before the fix, zero errors after.
- `pyright`: same result, zero errors after.

No runtime code changed, this is a stub-only fix, so I did not do a full C++ build for this PR.