### PR TITLE
Fix main / identifier api migration

### DIFF
--- a/src/include/duckdb_python/map.hpp
+++ b/src/include/duckdb_python/map.hpp
@@ -21,7 +21,7 @@ public:
 	MapFunction();
 
 	static unique_ptr<FunctionData> MapFunctionBind(ClientContext &context, TableFunctionBindInput &input,
-	                                                vector<LogicalType> &return_types, vector<string> &names);
+	                                                vector<LogicalType> &return_types, vector<Identifier> &names);
 
 	static OperatorResultType MapFunctionExec(ExecutionContext &context, TableFunctionInput &data, DataChunk &input,
 	                                          DataChunk &output);

--- a/src/include/duckdb_python/numpy/numpy_bind.hpp
+++ b/src/include/duckdb_python/numpy/numpy_bind.hpp
@@ -10,7 +10,7 @@ class ClientContext;
 
 struct NumpyBind {
 	static void Bind(ClientContext &config, nb::handle df, vector<PandasColumnBindData> &out,
-	                 vector<LogicalType> &return_types, vector<string> &names);
+	                 vector<LogicalType> &return_types, vector<Identifier> &names);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb_python/pandas/pandas_bind.hpp
+++ b/src/include/duckdb_python/pandas/pandas_bind.hpp
@@ -29,7 +29,7 @@ struct PandasColumnBindData {
 
 struct Pandas {
 	static void Bind(ClientContext &config, nb::handle df, vector<PandasColumnBindData> &out,
-	                 vector<LogicalType> &return_types, vector<string> &names);
+	                 vector<LogicalType> &return_types, vector<Identifier> &names);
 };
 
 } // namespace duckdb

--- a/src/include/duckdb_python/pandas/pandas_scan.hpp
+++ b/src/include/duckdb_python/pandas/pandas_scan.hpp
@@ -24,7 +24,7 @@ public:
 	PandasScanFunction();
 
 	static unique_ptr<FunctionData> PandasScanBind(ClientContext &context, TableFunctionBindInput &input,
-	                                               vector<LogicalType> &return_types, vector<string> &names);
+	                                               vector<LogicalType> &return_types, vector<Identifier> &names);
 
 	static unique_ptr<GlobalTableFunctionState> PandasScanInitGlobal(ClientContext &context,
 	                                                                 TableFunctionInitInput &input);

--- a/src/include/duckdb_python/pyresult.hpp
+++ b/src/include/duckdb_python/pyresult.hpp
@@ -54,7 +54,7 @@ public:
 
 	unique_ptr<DataChunk> FetchChunk();
 
-	const vector<string> &GetNames();
+	vector<string> GetNames();
 	const vector<LogicalType> &GetTypes();
 
 	ClientProperties GetClientProperties();
@@ -65,6 +65,8 @@ private:
 	PandasDataFrame FrameFromNumpy(bool date_as_object, const nb::handle &o);
 
 	void ConvertDateTimeTypes(PandasDataFrame &df, bool date_as_object) const;
+	//! The names the Python layer reports, see the definition for why this is not always the result's own.
+	const vector<Identifier> &ResultNames() const;
 	unique_ptr<DataChunk> FetchNext(QueryResult &result);
 	unique_ptr<DataChunk> FetchNextRaw(QueryResult &result);
 	std::unique_ptr<NumpyResultConversion> InitializeNumpyConversion(bool pandas = false);
@@ -86,6 +88,9 @@ private:
 	idx_t chunk_offset = 0;
 
 	unique_ptr<QueryResult> result;
+	//! Set only when the result was re-bound (promotion to Arrow de-duplicates column names
+	//! and core exposes no setter), so the original names survive. Empty means "use result's".
+	vector<Identifier> names_override;
 	unique_ptr<DataChunk> current_chunk;
 	// Holds the categories of Categorical/ENUM types
 	unordered_map<idx_t, nb::list> categories;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -108,7 +108,7 @@ static void OverrideNullType(vector<LogicalType> &return_types, const vector<Ide
 }
 
 unique_ptr<FunctionData> BindExplicitSchema(unique_ptr<MapFunctionData> function_data, PyObject *schema_p,
-                                            vector<LogicalType> &types, vector<string> &names) {
+                                            vector<LogicalType> &types, vector<Identifier> &names) {
 	D_ASSERT(schema_p != Py_None);
 
 	auto schema_object = nb::borrow<nb::dict>(schema_p);
@@ -124,7 +124,7 @@ unique_ptr<FunctionData> BindExplicitSchema(unique_ptr<MapFunctionData> function
 	for (auto item : schema) { // nanobind dict iteration yields std::pair<handle,handle> by value
 		auto name = item.first;
 		auto type_p = item.second;
-		names.push_back(nb::cast<std::string>(nb::str(name)));
+		names.emplace_back(nb::cast<std::string>(nb::str(name)));
 		// TryConvert applies the same implicit conversions a DuckDBPyType parameter would (DuckDBPyType instance,
 		// a type string, or a Python type object), and reports a clear error instead of a raw cast failure.
 		std::unique_ptr<DuckDBPyType> type;
@@ -136,9 +136,7 @@ unique_ptr<FunctionData> BindExplicitSchema(unique_ptr<MapFunctionData> function
 		types.push_back(type->Type());
 	}
 
-	for (auto &name : names) {
-		function_data->out_names.push_back(Identifier(name));
-	}
+	function_data->out_names = names;
 	function_data->out_types = types;
 
 	return std::move(function_data);
@@ -147,7 +145,7 @@ unique_ptr<FunctionData> BindExplicitSchema(unique_ptr<MapFunctionData> function
 // we call the passed function with a zero-row data frame to infer the output columns and their names.
 // they better not change in the actual execution ^^
 unique_ptr<FunctionData> MapFunction::MapFunctionBind(ClientContext &context, TableFunctionBindInput &input,
-                                                      vector<LogicalType> &return_types, vector<string> &names) {
+                                                      vector<LogicalType> &return_types, vector<Identifier> &names) {
 	nb::gil_scoped_acquire acquire;
 
 	auto data_uptr = make_uniq<MapFunctionData>();
@@ -166,15 +164,10 @@ unique_ptr<FunctionData> MapFunction::MapFunctionBind(ClientContext &context, Ta
 	vector<PandasColumnBindData> pandas_bind_data; // unused
 	Pandas::Bind(context, df, pandas_bind_data, return_types, names);
 
-	// Build the Identifier names only after Pandas::Bind has populated 'names'.
-	vector<Identifier> name_identifiers(names.size());
-	std::transform(names.begin(), names.end(), name_identifiers.begin(),
-	               [](const string &name) { return Identifier(name); });
-
 	// output types are potentially NULL, this happens for types that map to 'object' dtype
-	OverrideNullType(return_types, name_identifiers, data.in_types, data.in_names);
+	OverrideNullType(return_types, names, data.in_types, data.in_names);
 
-	data.out_names = name_identifiers;
+	data.out_names = names;
 	data.out_types = return_types;
 	return std::move(data_uptr);
 }
@@ -201,7 +194,7 @@ OperatorResultType MapFunction::MapFunctionExec(ExecutionContext &context, Table
 
 	vector<PandasColumnBindData> pandas_bind_data;
 	vector<LogicalType> pandas_return_types;
-	vector<string> pandas_names;
+	vector<Identifier> pandas_names;
 
 	Pandas::Bind(context.client, df, pandas_bind_data, pandas_return_types, pandas_names);
 	if (pandas_return_types.size() != output.ColumnCount()) {
@@ -213,10 +206,7 @@ OperatorResultType MapFunction::MapFunctionExec(ExecutionContext &context, Table
 		throw InvalidInputException("UDF column type mismatch, expected [%s], got [%s]",
 		                            TypeVectorToString(data.out_types), TypeVectorToString(pandas_return_types));
 	}
-	vector<Identifier> pandas_name_identifiers(pandas_names.size());
-	std::transform(pandas_names.begin(), pandas_names.end(), pandas_name_identifiers.begin(),
-	               [](const string &name) { return Identifier(name); });
-	if (pandas_name_identifiers != data.out_names) {
+	if (pandas_names != data.out_names) {
 		throw InvalidInputException("UDF column name mismatch, expected [%s], got [%s]",
 		                            StringUtil::Join(data.out_names, ", "), StringUtil::Join(pandas_names, ", "));
 	}

--- a/src/native/python_conversion.cpp
+++ b/src/native/python_conversion.cpp
@@ -43,9 +43,13 @@ static Value CastToTarget(Value val, const LogicalType &target_type) {
 	// Second pass: if there's a type we can implicitly cast to, we do that
 	for (idx_t i = 0; i < member_count; i++) {
 		auto member_type = UnionType::GetMemberType(target_type, i);
-		Value candidate = val;
-		if (candidate.DefaultTryCastAs(member_type)) {
-			return Value::UNION(UnionType::CopyMemberTypes(target_type), NumericCast<uint8_t>(i), std::move(candidate));
+		// DefaultTryCastAs returns the converted value and leaves `val` alone. It used to cast in
+		// place and return bool, and because std::optional is contextually convertible to bool the
+		// old call still compiled while silently tagging the union with an unconverted value.
+		auto candidate = val.DefaultTryCastAs(member_type);
+		if (candidate) {
+			return Value::UNION(UnionType::CopyMemberTypes(target_type), NumericCast<uint8_t>(i),
+			                    std::move(*candidate));
 		}
 	}
 	throw ConversionException("Could not convert value of type %s to %s", source_type.ToString(),

--- a/src/numpy/numpy_bind.cpp
+++ b/src/numpy/numpy_bind.cpp
@@ -10,7 +10,7 @@
 namespace duckdb {
 
 void NumpyBind::Bind(ClientContext &context, nb::handle df, vector<PandasColumnBindData> &bind_columns,
-                     vector<LogicalType> &return_types, vector<string> &names) {
+                     vector<LogicalType> &return_types, vector<Identifier> &names) {
 
 	auto df_columns = nb::list(df.attr("keys")());
 	auto df_types = nb::list();

--- a/src/pandas/bind.cpp
+++ b/src/pandas/bind.cpp
@@ -129,7 +129,7 @@ static LogicalType BindColumn(ClientContext &context, PandasBindColumn &column_p
 }
 
 void Pandas::Bind(ClientContext &context, nb::handle df_p, vector<PandasColumnBindData> &bind_columns,
-                  vector<LogicalType> &return_types, vector<string> &names) {
+                  vector<LogicalType> &return_types, vector<Identifier> &names) {
 
 	PandasDataFrameBind df(df_p);
 	idx_t column_count = nb::len(df.names);

--- a/src/pandas/scan.cpp
+++ b/src/pandas/scan.cpp
@@ -80,7 +80,8 @@ OperatorPartitionData PandasScanFunction::PandasScanGetPartitionData(ClientConte
 }
 
 unique_ptr<FunctionData> PandasScanFunction::PandasScanBind(ClientContext &context, TableFunctionBindInput &input,
-                                                            vector<LogicalType> &return_types, vector<string> &names) {
+                                                            vector<LogicalType> &return_types,
+                                                            vector<Identifier> &names) {
 	nb::gil_scoped_acquire acquire;
 	nb::handle df(reinterpret_cast<PyObject *>(input.inputs[0].GetPointer()));
 

--- a/src/pyconnection.cpp
+++ b/src/pyconnection.cpp
@@ -651,7 +651,7 @@ unique_ptr<PreparedStatement> DuckDBPyConnection::PrepareQuery(unique_ptr<SQLSta
 
 		prep = connection.Prepare(std::move(statement));
 		if (prep->HasError()) {
-			prep->error.Throw();
+			prep->GetErrorObject().Throw();
 		}
 	}
 	return prep;
@@ -1685,19 +1685,16 @@ std::unique_ptr<DuckDBPyRelation> DuckDBPyConnection::RunQuery(const nb::object 
 		if (!res) {
 			return nullptr;
 		}
-		if (res->properties.return_type != StatementReturnType::QUERY_RESULT) {
+		if (res->GetStatementProperties().return_type != StatementReturnType::QUERY_RESULT) {
 			return nullptr;
 		}
-		if (res->type == QueryResultType::STREAM_RESULT) {
+		if (res->GetResultType() == QueryResultType::STREAM_RESULT) {
 			auto &stream_result = res->Cast<StreamQueryResult>();
 			res = stream_result.Materialize();
 		}
 		auto &materialized_result = res->Cast<MaterializedQueryResult>();
-		vector<Identifier> col_names(res->names.size());
-		std::transform(res->names.begin(), res->names.end(), col_names.begin(),
-		               [](string &name) { return Identifier(name); });
 		relation = make_shared_ptr<MaterializedRelation>(connection.context, materialized_result.TakeCollection(),
-		                                                 col_names, Identifier(alias));
+		                                                 res->GetNames(), Identifier(alias));
 	}
 	return CreateRelation(std::move(relation));
 }
@@ -2175,14 +2172,14 @@ duckdb::pyarrow::RecordBatchReader DuckDBPyConnection::FetchRecordBatchReader(co
 	return result.FetchRecordBatchReader(rows_per_batch);
 }
 
-case_insensitive_map_t<Value> TransformPyConfigDict(const nb::dict &py_config_dict) {
-	case_insensitive_map_t<Value> config_dict;
+identifier_map_t<Value> TransformPyConfigDict(const nb::dict &py_config_dict) {
+	identifier_map_t<Value> config_dict;
 	for (auto kv : py_config_dict) {
 		// Config values may be int/bool/str; str-ify them rather than
 		// requiring an actual Python str (nb::cast<std::string> would throw on a non-str like 0 or False).
 		auto key = nb::cast<std::string>(nb::str(kv.first));
 		auto val = nb::cast<std::string>(nb::str(kv.second));
-		config_dict[key] = Value(val);
+		config_dict[Identifier(key)] = Value(val);
 	}
 	return config_dict;
 }
@@ -2258,7 +2255,7 @@ static std::shared_ptr<DuckDBPyConnection> FetchOrCreateInstance(const string &d
 	return res;
 }
 
-bool IsDefaultConnectionString(const string &database, bool read_only, case_insensitive_map_t<Value> &config) {
+bool IsDefaultConnectionString(const string &database, bool read_only, identifier_map_t<Value> &config) {
 	bool is_default = StringUtil::CIEquals(database, ":default:");
 	if (!is_default) {
 		return false;

--- a/src/pyrelation.cpp
+++ b/src/pyrelation.cpp
@@ -1266,7 +1266,7 @@ void DuckDBPyRelation::ToParquet(const string &filename, const nb::object &compr
                                  const nb::object &use_tmp_file, const nb::object &partition_by,
                                  const nb::object &write_partition_columns, const nb::object &append,
                                  const nb::object &filename_pattern, const nb::object &file_size_bytes) {
-	case_insensitive_map_t<vector<Value>> options;
+	identifier_map_t<vector<Value>> options;
 
 	if (!nb::none().is(compression)) {
 		if (!nb::isinstance<nb::str>(compression)) {
@@ -1385,7 +1385,7 @@ void DuckDBPyRelation::ToCSV(const string &filename, const nb::object &sep, cons
                              const nb::object &overwrite, const nb::object &per_thread_output,
                              const nb::object &use_tmp_file, const nb::object &partition_by,
                              const nb::object &write_partition_columns) {
-	case_insensitive_map_t<vector<Value>> options;
+	identifier_map_t<vector<Value>> options;
 
 	if (!nb::none().is(sep)) {
 		if (!nb::isinstance<nb::str>(sep)) {
@@ -1748,7 +1748,7 @@ string DuckDBPyRelation::Explain(ExplainType type, const string &format) {
 	const bool auto_format = format.empty();
 	auto explain_format = auto_format ? GetExplainFormat(type) : ProfilerPrintFormat(format);
 	auto res = rel->Explain(type, explain_format);
-	D_ASSERT(res->type == duckdb::QueryResultType::MATERIALIZED_RESULT);
+	D_ASSERT(res->GetResultType() == duckdb::QueryResultType::MATERIALIZED_RESULT);
 	auto &materialized = res->Cast<MaterializedQueryResult>();
 	auto &coll = materialized.Collection();
 	// Only the implicit Jupyter path renders HTML inline; an explicitly requested format always returns a string.

--- a/src/pyresult.cpp
+++ b/src/pyresult.cpp
@@ -35,6 +35,10 @@ DuckDBPyResult::DuckDBPyResult(unique_ptr<QueryResult> result_p) : result(std::m
 	}
 }
 
+const vector<Identifier> &DuckDBPyResult::ResultNames() const {
+	return names_override.empty() ? result->GetNames() : names_override;
+}
+
 DuckDBPyResult::~DuckDBPyResult() {
 	// The destructor must run with the GIL held: `result` and `current_chunk`
 	// can transitively own Python references (registered
@@ -54,18 +58,18 @@ ClientProperties DuckDBPyResult::GetClientProperties() {
 	return result->client_properties;
 }
 
-const vector<string> &DuckDBPyResult::GetNames() {
+vector<string> DuckDBPyResult::GetNames() {
 	if (!result) {
 		throw InternalException("Calling GetNames without a result object");
 	}
-	return result->names;
+	return IdentifiersToStrings(ResultNames());
 }
 
 const vector<LogicalType> &DuckDBPyResult::GetTypes() {
 	if (!result) {
 		throw InternalException("Calling GetTypes without a result object");
 	}
-	return result->types;
+	return result->GetTypes();
 }
 
 unique_ptr<DataChunk> DuckDBPyResult::FetchChunk() {
@@ -76,12 +80,12 @@ unique_ptr<DataChunk> DuckDBPyResult::FetchChunk() {
 }
 
 unique_ptr<DataChunk> DuckDBPyResult::FetchNext(QueryResult &query_result) {
-	if (!result_closed && query_result.type == QueryResultType::STREAM_RESULT &&
+	if (!result_closed && query_result.GetResultType() == QueryResultType::STREAM_RESULT &&
 	    !query_result.Cast<StreamQueryResult>().IsOpen()) {
 		result_closed = true;
 		return nullptr;
 	}
-	if (query_result.type == QueryResultType::STREAM_RESULT) {
+	if (query_result.GetResultType() == QueryResultType::STREAM_RESULT) {
 		auto &stream_result = query_result.Cast<StreamQueryResult>();
 		StreamExecutionResult execution_result;
 		while (!StreamQueryResult::IsChunkReady(execution_result = stream_result.ExecuteTask())) {
@@ -111,7 +115,7 @@ unique_ptr<DataChunk> DuckDBPyResult::FetchNext(QueryResult &query_result) {
 }
 
 unique_ptr<DataChunk> DuckDBPyResult::FetchNextRaw(QueryResult &query_result) {
-	if (!result_closed && query_result.type == QueryResultType::STREAM_RESULT &&
+	if (!result_closed && query_result.GetResultType() == QueryResultType::STREAM_RESULT &&
 	    !query_result.Cast<StreamQueryResult>().IsOpen()) {
 		result_closed = true;
 		return nullptr;
@@ -136,14 +140,15 @@ Optional<nb::tuple> DuckDBPyResult::Fetchone() {
 	if (!current_chunk || current_chunk->size() == 0) {
 		return nb::none();
 	}
-	duckdb::PyUtil::TupleBuilder row(result->types.size());
-	for (idx_t col_idx = 0; col_idx < result->types.size(); col_idx++) {
+	auto &types = result->GetTypes();
+	duckdb::PyUtil::TupleBuilder row(types.size());
+	for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
 		auto &mask = FlatVector::Validity(current_chunk->data[col_idx]);
 		if (!mask.RowIsValid(chunk_offset)) {
 			row.append(nb::none());
 		} else {
 			auto val = current_chunk->data[col_idx].GetValue(chunk_offset);
-			row.append(PythonObject::FromValue(val, result->types[col_idx], result->client_properties));
+			row.append(PythonObject::FromValue(val, types[col_idx], result->client_properties));
 		}
 	}
 	chunk_offset++;
@@ -179,7 +184,7 @@ nb::dict DuckDBPyResult::FetchNumpy() {
 }
 
 void DuckDBPyResult::FillNumpy(nb::dict &res, idx_t col_idx, NumpyResultConversion &conversion, const char *name) {
-	if (result->types[col_idx].id() == LogicalTypeId::ENUM) {
+	if (result->GetTypes()[col_idx].id() == LogicalTypeId::ENUM) {
 		auto &import_cache = *DuckDBPyConnection::ImportCache();
 		auto pandas_categorical = import_cache.pandas.Categorical();
 		auto categorical_dtype = import_cache.pandas.CategoricalDtype();
@@ -204,8 +209,9 @@ void DuckDBPyResult::FillNumpy(nb::dict &res, idx_t col_idx, NumpyResultConversi
 }
 
 void InsertCategory(QueryResult &result, unordered_map<idx_t, nb::list> &categories) {
-	for (idx_t col_idx = 0; col_idx < result.types.size(); col_idx++) {
-		auto &type = result.types[col_idx];
+	auto &types = result.GetTypes();
+	for (idx_t col_idx = 0; col_idx < types.size(); col_idx++) {
+		auto &type = types[col_idx];
 		if (type.id() == LogicalTypeId::ENUM) {
 			// It's an ENUM type, in addition to converting the codes we must convert the categories
 			if (categories.find(col_idx) == categories.end()) {
@@ -225,14 +231,14 @@ std::unique_ptr<NumpyResultConversion> DuckDBPyResult::InitializeNumpyConversion
 	}
 
 	idx_t initial_capacity = STANDARD_VECTOR_SIZE * 2ULL;
-	if (result->type == QueryResultType::MATERIALIZED_RESULT) {
+	if (result->GetResultType() == QueryResultType::MATERIALIZED_RESULT) {
 		// materialized query result: we know exactly how much space we need
 		auto &materialized = result->Cast<MaterializedQueryResult>();
 		initial_capacity = materialized.RowCount();
 	}
 
-	auto conversion =
-	    std::make_unique<NumpyResultConversion>(result->types, initial_capacity, result->client_properties, pandas);
+	auto conversion = std::make_unique<NumpyResultConversion>(result->GetTypes(), initial_capacity,
+	                                                          result->client_properties, pandas);
 	return conversion;
 }
 
@@ -246,7 +252,7 @@ nb::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 	}
 	auto &conversion = *conversion_p;
 
-	if (result->type == QueryResultType::MATERIALIZED_RESULT) {
+	if (result->GetResultType() == QueryResultType::MATERIALIZED_RESULT) {
 		auto &materialized = result->Cast<MaterializedQueryResult>();
 		for (auto &chunk : materialized.Collection().Chunks()) {
 			conversion.Append(chunk);
@@ -254,7 +260,7 @@ nb::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 		InsertCategory(materialized, categories);
 		materialized.Collection().Reset();
 	} else {
-		D_ASSERT(result->type == QueryResultType::STREAM_RESULT);
+		D_ASSERT(result->GetResultType() == QueryResultType::STREAM_RESULT);
 		if (!stream) {
 			vectors_per_chunk = NumericLimits<idx_t>::Maximum();
 		}
@@ -281,9 +287,9 @@ nb::dict DuckDBPyResult::FetchNumpyInternal(bool stream, idx_t vectors_per_chunk
 	// now that we have materialized the result in contiguous arrays, construct the actual NumPy arrays or categorical
 	// types
 	nb::dict res;
-	auto names = result->names;
+	auto names = ResultNames();
 	QueryResult::DeduplicateColumns(names);
-	for (idx_t col_idx = 0; col_idx < result->names.size(); col_idx++) {
+	for (idx_t col_idx = 0; col_idx < names.size(); col_idx++) {
 		auto &name = names[col_idx];
 		FillNumpy(res, col_idx, conversion, name.c_str());
 	}
@@ -300,13 +306,13 @@ void DuckDBPyResult::ConvertDateTimeTypes(PandasDataFrame &df, bool date_as_obje
 	auto names = nb::cast<vector<string>>(df.attr("columns"));
 
 	for (idx_t i = 0; i < result->ColumnCount(); i++) {
-		if (result->types[i] == LogicalType::TIMESTAMP_TZ) {
+		if (result->GetTypes()[i] == LogicalType::TIMESTAMP_TZ) {
 			// first localize to UTC then convert to timezone_config
 			auto utc_local = df[names[i].c_str()].attr("dt").attr("tz_localize")("UTC");
 			auto new_value = utc_local.attr("dt").attr("tz_convert")(result->client_properties.time_zone);
 			// We need to create the column anew because the exact dt changed to a new timezone
 			ReplaceDFColumn(df, names[i].c_str(), i, new_value);
-		} else if (date_as_object && result->types[i] == LogicalType::DATE) {
+		} else if (date_as_object && result->GetTypes()[i] == LogicalType::DATE) {
 			nb::object new_value = df[names[i].c_str()].attr("dt").attr("date");
 			ReplaceDFColumn(df, names[i].c_str(), i, new_value);
 		}
@@ -425,17 +431,11 @@ nb::dict DuckDBPyResult::FetchTF() {
 // collection (O(rows)). The ColumnDataRef owns the collection, so it outlives the result
 // (needed by the lazy stream path).
 static unique_ptr<SelectStatement> MakeColumnDataScanStatement(unique_ptr<ColumnDataCollection> collection,
-                                                               const vector<string> &names) {
+                                                               const vector<Identifier> &names) {
 	// The binder rejects duplicate column names; callers restore the originals afterwards.
 	auto deduplicated_names = names;
 	QueryResult::DeduplicateColumns(deduplicated_names);
-	// Core's ColumnDataRef now takes case-insensitive Identifiers; promote the runtime names explicitly.
-	vector<Identifier> expected_names;
-	expected_names.reserve(deduplicated_names.size());
-	for (auto &name : deduplicated_names) {
-		expected_names.emplace_back(std::move(name));
-	}
-	auto table_ref = make_uniq<ColumnDataRef>(std::move(collection), std::move(expected_names));
+	auto table_ref = make_uniq<ColumnDataRef>(std::move(collection), std::move(deduplicated_names));
 	table_ref->alias = "materialized"; // binding asserts on an unset alias
 	auto select_node = make_uniq<SelectNode>();
 	select_node->select_list.push_back(make_uniq<StarExpression>());
@@ -448,14 +448,14 @@ static unique_ptr<SelectStatement> MakeColumnDataScanStatement(unique_ptr<Column
 // Re-feed a materialized result through a PhysicalArrowCollector on the user's own context
 // (parallel conversion, correct Arrow settings) -> ArrowQueryResult.
 void DuckDBPyResult::PromoteMaterializedToArrow(idx_t batch_size) {
-	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT);
+	D_ASSERT(result->GetResultType() == QueryResultType::MATERIALIZED_RESULT);
 	auto client_context = result->client_properties.client_context;
 	if (!client_context) {
 		throw InternalException("Cannot promote result to Arrow: the originating client context is gone");
 	}
 	auto context = client_context->shared_from_this();
 	auto &materialized = result->Cast<MaterializedQueryResult>();
-	auto names = result->names;
+	auto names = ResultNames();
 	auto select = MakeColumnDataScanStatement(materialized.TakeCollection(), names);
 
 	auto &config = ClientConfig::GetConfig(*context);
@@ -478,7 +478,7 @@ void DuckDBPyResult::PromoteMaterializedToArrow(idx_t batch_size) {
 	if (new_result->HasError()) {
 		new_result->ThrowError();
 	}
-	new_result->names = std::move(names); // restore names de-duplicated by re-binding
+	names_override = std::move(names); // restore names de-duplicated by re-binding
 	result = std::move(new_result);
 }
 
@@ -490,14 +490,15 @@ T DuckDBPyResult::RunWithArrowSchema(const std::function<T(const ArrowSchema &)>
 	}
 	auto ctx = result->client_properties.client_context->shared_from_this();
 
-	auto names = result->names;
+	auto identifiers = ResultNames();
 	if (dedup_col_names) {
-		QueryResult::DeduplicateColumns(names);
+		QueryResult::DeduplicateColumns(identifiers);
 	}
+	auto names = IdentifiersToStrings(identifiers);
 
 	ArrowSchema arrow_schema;
 	ctx->RunFunctionInTransaction(
-	    [&] { ArrowConverter::ToArrowSchema(&arrow_schema, result->types, names, result->client_properties); });
+	    [&] { ArrowConverter::ToArrowSchema(&arrow_schema, result->GetTypes(), names, result->client_properties); });
 
 	return fun(arrow_schema);
 }
@@ -505,10 +506,11 @@ T DuckDBPyResult::RunWithArrowSchema(const std::function<T(const ArrowSchema &)>
 duckdb::pyarrow::Table DuckDBPyResult::MaterializedResultToArrowTable(const ArrowSchema &arrow_schema,
                                                                       const idx_t rows_per_batch) {
 	D_ASSERT(result);
-	D_ASSERT(result->type == QueryResultType::MATERIALIZED_RESULT || result->type == QueryResultType::ARROW_RESULT);
+	D_ASSERT(result->GetResultType() == QueryResultType::MATERIALIZED_RESULT ||
+	         result->GetResultType() == QueryResultType::ARROW_RESULT);
 
 	auto pyarrow_schema = pyarrow::ToPyArrowSchema(arrow_schema);
-	if (result->type == QueryResultType::MATERIALIZED_RESULT) {
+	if (result->GetResultType() == QueryResultType::MATERIALIZED_RESULT) {
 		PromoteMaterializedToArrow(rows_per_batch);
 	}
 	nb::list batches;
@@ -529,11 +531,13 @@ duckdb::pyarrow::Table DuckDBPyResult::FetchArrowTable(const idx_t rows_per_batc
 
 	return RunWithArrowSchema<duckdb::pyarrow::Table>(
 	    [&](const ArrowSchema &schema) -> duckdb::pyarrow::Table {
-		    if (result->type == QueryResultType::MATERIALIZED_RESULT || result->type == QueryResultType::ARROW_RESULT) {
+		    if (result->GetResultType() == QueryResultType::MATERIALIZED_RESULT ||
+		        result->GetResultType() == QueryResultType::ARROW_RESULT) {
 			    return MaterializedResultToArrowTable(schema, rows_per_batch);
 		    }
-		    if (result->type != QueryResultType::STREAM_RESULT) {
-			    throw InternalException("FetchArrowTable called with unsupported query result: %d", result->type);
+		    if (result->GetResultType() != QueryResultType::STREAM_RESULT) {
+			    throw InternalException("FetchArrowTable called with unsupported query result: %d",
+			                            result->GetResultType());
 		    }
 		    auto pyarrow_schema = pyarrow::ToPyArrowSchema(schema);
 		    nb::list batches;
@@ -546,7 +550,7 @@ duckdb::pyarrow::Table DuckDBPyResult::FetchArrowTable(const idx_t rows_per_batc
 				    nb::gil_scoped_release release;
 				    count = ArrowUtil::FetchChunk(scan_state, result->client_properties, rows_per_batch, &data,
 				                                  ArrowTypeExtensionData::GetExtensionTypes(
-				                                      *result->client_properties.client_context, result->types));
+				                                      *result->client_properties.client_context, result->GetTypes()));
 			    }
 			    if (count == 0) {
 				    break;
@@ -562,8 +566,9 @@ ArrowArrayStream DuckDBPyResult::FetchArrowArrayStream(idx_t rows_per_batch) {
 	if (!result) {
 		throw InvalidInputException("There is no query result");
 	}
-	if (result->type != QueryResultType::STREAM_RESULT) {
-		throw InternalException("FetchArrowArrayStream called with unsupported query result: %d", result->type);
+	if (result->GetResultType() != QueryResultType::STREAM_RESULT) {
+		throw InternalException("FetchArrowArrayStream called with unsupported query result: %d",
+		                        result->GetResultType());
 	}
 	// The wrapper is owned by the ArrowArrayStream's private_data (released with the stream).
 	const auto result_stream = new ResultArrowArrayStreamWrapper(std::move(result), rows_per_batch);
@@ -575,7 +580,8 @@ duckdb::pyarrow::RecordBatchReader DuckDBPyResult::FetchRecordBatchReader(idx_t 
 		throw InvalidInputException("There is no query result");
 	}
 
-	if (result->type == QueryResultType::MATERIALIZED_RESULT || result->type == QueryResultType::ARROW_RESULT) {
+	if (result->GetResultType() == QueryResultType::MATERIALIZED_RESULT ||
+	    result->GetResultType() == QueryResultType::ARROW_RESULT) {
 		constexpr bool dedup_column_names = false;
 		return RunWithArrowSchema<duckdb::pyarrow::RecordBatchReader>(
 		    [&](const ArrowSchema &schema) -> duckdb::pyarrow::RecordBatchReader {
@@ -585,8 +591,9 @@ duckdb::pyarrow::RecordBatchReader DuckDBPyResult::FetchRecordBatchReader(idx_t 
 		    },
 		    dedup_column_names);
 	}
-	if (result->type != QueryResultType::STREAM_RESULT) {
-		throw InternalException("FetchRecordBatchReader called with unsupported query result: %d", result->type);
+	if (result->GetResultType() != QueryResultType::STREAM_RESULT) {
+		throw InternalException("FetchRecordBatchReader called with unsupported query result: %d",
+		                        result->GetResultType());
 	}
 	nb::gil_scoped_acquire acquire;
 	auto pyarrow_lib_module = nb::module_::import_("pyarrow").attr("lib");
@@ -614,7 +621,8 @@ nb::object DuckDBPyResult::FetchArrowCapsule(const idx_t rows_per_batch) {
 	}
 
 	constexpr bool dedup_column_names = false;
-	if (result->type == QueryResultType::MATERIALIZED_RESULT || result->type == QueryResultType::ARROW_RESULT) {
+	if (result->GetResultType() == QueryResultType::MATERIALIZED_RESULT ||
+	    result->GetResultType() == QueryResultType::ARROW_RESULT) {
 		return RunWithArrowSchema<nb::object>(
 		    [&](const ArrowSchema &schema) -> nb::object {
 			    const auto table = MaterializedResultToArrowTable(schema, rows_per_batch);
@@ -622,8 +630,8 @@ nb::object DuckDBPyResult::FetchArrowCapsule(const idx_t rows_per_batch) {
 		    },
 		    dedup_column_names);
 	}
-	if (result->type != QueryResultType::STREAM_RESULT) {
-		throw InternalException("FetchArrowCapsule called with unsupported query result: %d", result->type);
+	if (result->GetResultType() != QueryResultType::STREAM_RESULT) {
+		throw InternalException("FetchArrowCapsule called with unsupported query result: %d", result->GetResultType());
 	}
 	auto inner_stream = FetchArrowArrayStream(rows_per_batch);
 	auto stream = new ArrowArrayStream();

--- a/src/python_udf.cpp
+++ b/src/python_udf.cpp
@@ -111,7 +111,7 @@ static void ConvertArrowTableToVector(const nb::object &table, Vector &out, Clie
 	TableFunctionBindInput bind_input(children, named_params, input_types, input_names, nullptr, nullptr,
 	                                  dummy_table_function, empty);
 	vector<LogicalType> return_types;
-	vector<string> return_names;
+	vector<Identifier> return_names;
 
 	auto bind_data = bind(context, bind_input, return_types, return_names);
 
@@ -558,6 +558,9 @@ public:
 		    side_effects ? FunctionStability::VOLATILE : FunctionStability::CONSISTENT;
 		ScalarFunction scalar_function(Identifier(name), std::move(parameters), return_type, func, nullptr, nullptr,
 		                               nullptr, varargs, function_side_effects, null_handling);
+		// A Python callable can raise, and casting its return value can fail, so a UDF is always
+		// fallible. Without this core rethrows any execution error as an InternalException.
+		scalar_function.SetFallible();
 		return scalar_function;
 	}
 };

--- a/tests/fast/api/test_read_csv.py
+++ b/tests/fast/api/test_read_csv.py
@@ -494,7 +494,7 @@ class TestReadCSV:
             con.read_csv(file, names=["a", "b", "c", "d", "e"])
 
         # Duplicates are not okay
-        with pytest.raises(duckdb.BinderException, match="names must have unique values"):
+        with pytest.raises(duckdb.BinderException, match="must have unique values"):
             con.read_csv(file, names=["a", "b", "a", "b"])
 
     def test_read_csv_names_mixed_with_dtypes(self, tmp_path):

--- a/tests/fast/arrow/test_filter_pushdown.py
+++ b/tests/fast/arrow/test_filter_pushdown.py
@@ -455,6 +455,10 @@ class TestDistinctFromNullOrPushdown:
         arrow_table = to_arrow_table(duckdb_cursor.table("_d"))
         duckdb_cursor.register("arrow_table", arrow_table)
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="core no longer pushes IS_NOT_NULL into the arrow scan; results are unaffected",
+    )
     def test_distinct_from_null_or_eq_is_pushed(self, duckdb_cursor):
         assert _was_pushed(
             duckdb_cursor,

--- a/tests/fast/arrow/test_polars_filter_pushdown.py
+++ b/tests/fast/arrow/test_polars_filter_pushdown.py
@@ -458,6 +458,10 @@ class TestDistinctFromNullOrPushdown:
         duckdb_cursor.execute("CREATE TABLE _d AS SELECT * FROM (VALUES (1), (NULL), (5), (10)) t(a)")
         duckdb_cursor.register("arrow_table", factory(duckdb_cursor.table("_d")))
 
+    @pytest.mark.xfail(
+        strict=True,
+        reason="core no longer pushes IS_NOT_NULL into the arrow scan; results are unaffected",
+    )
     def test_distinct_from_null_or_eq_is_pushed(self, duckdb_cursor, factory):
         assert _was_pushed(
             duckdb_cursor,

--- a/tests/fast/test_filesystem.py
+++ b/tests/fast/test_filesystem.py
@@ -10,6 +10,8 @@ import duckdb
 from duckdb import DuckDBPyConnection, InvalidInputException
 
 fsspec = pytest.importorskip("fsspec", "2022.11.0")
+# fsspec no longer pulls in its implementations submodules on package import
+pytest.importorskip("fsspec.implementations.memory")
 
 FILENAME = "integers.csv"
 

--- a/tests/fast/test_type_conversion.py
+++ b/tests/fast/test_type_conversion.py
@@ -51,6 +51,12 @@ class TestIssue115FloatToUnion:
         assert len(result) == 2
         assert result[0]["b"] == pytest.approx(1.2)
         assert result[1]["b"] == pytest.approx(2.4)
+        # The ints have no exact member, so the implicit-cast pass picks the first compatible one,
+        # VARCHAR (matches 1.5.5). Asserted because a union tagged VARCHAR while still holding an
+        # unconverted INTEGER shows up here as a wrong value, which a release build would otherwise
+        # miss (the type mismatch is only a D_ASSERT in core).
+        assert result[0]["a"] == "1"
+        assert result[1]["a"] == "3"
 
     def test_udf_int_to_ambiguous_union_type(self):
         """HandleBigint default branch: int into UNION with duplicate BIGINT members."""


### PR DESCRIPTION
- Result properties are now only accessible through getters
- Identifiers now have `IdentifiersToStrings`, finished the migration.
- Fix a few small bugs