### PR TITLE
CI: Fix gcovr paths for Test coverage

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -113,7 +113,7 @@ jobs:
             --gcov-ignore-errors all \
             --gcov-ignore-parse-errors=negative_hits.warn_once_per_file \
             --root "$PWD" \
-            --filter "${PWD}/src/duckdb_py" \
+            --filter "${PWD}/src" \
             --exclude '.*/\.cache/.*' \
             --gcov-exclude '.*/\.cache/.*' \
             --gcov-exclude '.*/external/.*' \
@@ -121,7 +121,7 @@ jobs:
             --exclude-unreachable-branches \
             --exclude-throw-branches \
             --html --html-details -o coverage-cpp/index.html \
-            build/coverage/src/duckdb_py \
+            build/coverage/src \
             --print-summary > cpp_summary.txt
           # save the summary in the output
           echo "summary<<EOF" >> $GITHUB_OUTPUT

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ build-backend = "duckdb_packaging.build_backend"
 backend-path = ["./"]
 requires = [
     "scikit-build-core>=0.11.4",
-	"nanobind>=2.0",
+	"nanobind>=2.0,<3.0",
     "setuptools_scm>=8.0",
     # numpy C API headers (PyArray_Empty in the result path). Building against numpy 2.x yields a
     # binary compatible with numpy >=1.19 AND 2.x at runtime (numpy 2.0 backward-compat), so the
@@ -319,7 +319,7 @@ pypi = [ # dependencies used by the pypi cleanup script
 build = [
     "cmake>=3.29.0",
     "ninja>=1.10",
-    "nanobind>=2.0",
+	"nanobind>=2.0,<3.0",
     "scikit_build_core>=0.11.4",
     "setuptools_scm>=8.0",
 ]


### PR DESCRIPTION
This is a small fix to fix coverage.yml workflow, broken since #522. 

Root cause is [`1231037`](https://github.com/duckdb/duckdb-python/commit/1231037c890aaab337cf4e53cbbb7c84bad0dac7). The specific problem is that `src/duckdb_py/*` was moved up to `src/*`, but `coverage.yml` still passes the old path to gcovr, and fails (40+ minutes in).

This PR corrects the gocvr path.

\* It also pins nanobind < 3.0, due to unrelated problem with nanobind 3.0.0. 