### PR TITLE
CI: Improving Cache Hit Rates and Seeding

### DIFF
--- a/.github/actions/build-wheel/action.yml
+++ b/.github/actions/build-wheel/action.yml
@@ -122,7 +122,7 @@ runs:
     #   traversing the full filesystem, which produces an error on Windows.
     # - CIBW_TEST_SKIP we always skip tests for *-macosx_universal2 builds, because we run tests for arm64 and x86_64.
     - name: Build${{ inputs.testsuite != 'none' && ' and test ' || ' ' }}wheel
-      uses: pypa/cibuildwheel@v3.2
+      uses: pypa/cibuildwheel@v4.2.0
       env:
         CIBW_ARCHS: ${{ inputs.arch == 'amd64' && 'AMD64' || inputs.arch }}
         CIBW_BUILD: ${{ inputs.python }}-${{ inputs.cibw-system }}_${{ inputs.arch }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -521,9 +521,10 @@ before-build = [
 ]
 # nanobind uses C++17 aligned new/delete (std::align_val_t), which the runtime only provides on macOS 10.13+.
 # cp311's framework defaults to a 10.9 deployment target (used for the x86_64 slice of x86_64/universal2
-# wheels), so nanobind fails to compile there; cp312+ frameworks already target 10.13+. Pin 10.14 so every CPython
-# version builds (arm64 slices are 11.0 regardless).
-environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
+# wheels), so nanobind fails to compile there; cp312+ frameworks already target 10.13+. 
+# cibuildwheel bumps automatically to the minimum per target, so use a minimum that'll work on all python versions
+# otherwise caching is defeated
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
 
 [tool.cibuildwheel.windows]
 build-frontend = { name = "build", args = ["--env-dir", "C:/duckdb-build-env"] }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ build-backend = "duckdb_packaging.build_backend"
 backend-path = ["./"]
 requires = [
     "scikit-build-core>=0.11.4",
-	"nanobind>=2.0,<3.0",
+	"nanobind>=3.0",
     "setuptools_scm>=8.0",
     # numpy C API headers (PyArray_Empty in the result path). Building against numpy 2.x yields a
     # binary compatible with numpy >=1.19 AND 2.x at runtime (numpy 2.0 backward-compat), so the
@@ -324,7 +324,7 @@ pypi = [ # dependencies used by the pypi cleanup script
 build = [
     "cmake>=3.29.0",
     "ninja>=1.10",
-    "nanobind>=2.0,<3.0",
+    "nanobind>=3.0",
     "scikit_build_core>=0.11.4",
     "setuptools_scm>=8.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ build-backend = "duckdb_packaging.build_backend"
 backend-path = ["./"]
 requires = [
     "scikit-build-core>=0.11.4",
-	"nanobind>=2.0",
+	"nanobind>=2.0,<3.0",
     "setuptools_scm>=8.0",
     # numpy C API headers (PyArray_Empty in the result path). Building against numpy 2.x yields a
     # binary compatible with numpy >=1.19 AND 2.x at runtime (numpy 2.0 backward-compat), so the
@@ -102,6 +102,11 @@ fallback_version = "0.0.1.dev1"
 # Release branches must NOT have this, they correctly count from v*.*.* (the default).
 [tool.setuptools_scm.scm.git]
 describe_command = "git describe --dirty --tags --long --abbrev=40 --match v*.*.0"
+
+[[tool.scikit-build.overrides]]
+if.env.CIBUILDWHEEL_BUILD_IDENTIFIER = true
+build-dir = "build/shared"
+build.tool-args = ["-v"]
 
 # Override: if COVERAGE is set then:
 # - we create a RelWithDebInfo build
@@ -319,7 +324,7 @@ pypi = [ # dependencies used by the pypi cleanup script
 build = [
     "cmake>=3.29.0",
     "ninja>=1.10",
-    "nanobind>=2.0",
+    "nanobind>=2.0,<3.0",
     "scikit_build_core>=0.11.4",
     "setuptools_scm>=8.0",
 ]
@@ -492,6 +497,8 @@ indent-style = "space"
 # (to some extent).
 ######################################################################################################
 [tool.cibuildwheel]
+# --env-dir needs build>=1.6.0; cibuildwheel pins build==1.5.0
+dependency-versions = "latest"
 build-frontend = "build[uv]"
 manylinux-x86_64-image = "manylinux_2_28"
 manylinux-pypy_x86_64-image = "manylinux_2_28"
@@ -499,10 +506,19 @@ manylinux-aarch64-image = "manylinux_2_28"
 manylinux-pypy_aarch64-image = "manylinux_2_28"
 
 [tool.cibuildwheel.linux]
-before-build = ["yum install -y ccache"]
+build-frontend = { name = "build[uv]", args = ["--env-dir", "/tmp/duckdb-build-env"] }
+before-build = [
+  'pip install -U "build>=1.6.0"',
+  'rm -rf /tmp/duckdb-build-env',
+  'yum install -y ccache',
+]
 
 [tool.cibuildwheel.macos]
-before-build = ["brew install ccache"]
+build-frontend = { name = "build[uv]", args = ["--env-dir", "/tmp/duckdb-build-env"] }
+before-build = [
+  'rm -rf /tmp/duckdb-build-env',
+  'brew install ccache',
+]
 # nanobind uses C++17 aligned new/delete (std::align_val_t), which the runtime only provides on macOS 10.13+.
 # cp311's framework defaults to a 10.9 deployment target (used for the x86_64 slice of x86_64/universal2
 # wheels), so nanobind fails to compile there; cp312+ frameworks already target 10.13+. Pin 10.14 so every CPython
@@ -510,4 +526,8 @@ before-build = ["brew install ccache"]
 environment = { MACOSX_DEPLOYMENT_TARGET = "10.14" }
 
 [tool.cibuildwheel.windows]
-before-build = ["choco install ccache"]
+build-frontend = { name = "build", args = ["--env-dir", "C:/duckdb-build-env"] }
+before-build = [
+  'if exist C:\duckdb-build-env (rmdir /s /q C:\duckdb-build-env)',
+  'choco install ccache -y',
+]


### PR DESCRIPTION
## Summary
After #559, there's a few more ways to improve caching and get the seeds to 100% hit rates:
- Use a stable --env-dir so that the Python compilation units are cacheable
- Use a stable build-dir so that the fanout builds can fully use the seed builds
- Raise the MACSX_DEPLOYMENT_TARGET so that the cp311 builds can use the seed builds

## Current problems
1. cibuildwheel uses a random path dir which causes the Python compilation units to consistently miss. There hasn't been a great solution until yesterday (2026-08-27) when pypa/build 1.6.0 shipped: [#1083 control the isolated build environment location w --env-dir](https://github.com/pypa/build/pull/1083). This feature will solve one specific issue: the 51 cache misses in the seed builds due to the random build path created by cibuildwheel. 

2. Using a dynamic build-dir means that each build is contaminated by the cache_tag: the cache_tag ends up part of some ccache compile calls, which then aren't reused across builds.
https://github.com/duckdb/duckdb-python/blob/6239d169683d93e67a1d522b5d47c4a60e13918f/pyproject.toml#L84

3. The seed cache is dependent on the MACOSX_DEPLOYMENT_TARGET, set here:
https://github.com/duckdb/duckdb-python/blob/6239d169683d93e67a1d522b5d47c4a60e13918f/pyproject.toml#L510
but cibuildwheel will autoadjust that to 10.15 for some builds and ignore your input: [cibuildwheel MACOSX_DEPLOYMENT_TARGET](https://github.com/pypa/cibuildwheel/blob/9c00cb4f6b517705a3794b22395aedc36257242c/cibuildwheel/platforms/macos.py#L307-L313). This causes a mismatch between cp311 and other builds, causing cp311 to miss.

Alternative: If you need to support cp311 on 10.14, then could also move it up to seed so it generates its own cache. 

## Changes
- Use --env-dir and pypa/build 1.6.0 to eliminate the random Python dir. 
- Set build-dir to a constant when running cibuildwheel
- Use a deployment target that works for all builds: 10.15.
- add verbose logging to help with future debugging: you need the full path to see what's changed
Versions
- cibuildwheel to 4.2.0 (latest)
- nanobind < 3.0 (mentioned elsewhere, needed for builds due to a breaking change)

## Current State Notes
- seeds get about 88% hits. The 51 misses are the Python misses fixed by the `--env-dir` change above
- The fanouts are around ~50% due to the `{cache_tag}`.
- The cp311 macos x86_64 builds have a 0% cache hit rate due to the  MACOSX_DEPLOYMENT_TARGET

## Impact
- 100% cache hits on seeds vs 88% 
- ~88% cache hits on the fanout vs ~51%
- Reference: https://github.com/duckdb/duckdb-python/actions/runs/32117618656/job/95671628960
- The forked seeds are more or less the same time: the cache hits don't have a significant runtime difference, since it's dominated by test time and the 51 python units are fairly fast.
- The forked fanout/matrix builds are 5-10 minutes faster... the caching makes a big difference. 

## Futures / other optimizations worth considering
- Two tests are about 30% of total runtime: `test_executemany_leak` and `test_materialized_relation[10000000]`
- Don't install ccache twice on Windows and macosx. This is 30sec-1min. 
- Don't install ccache from EPEL on Linux, use curl & cache it. I saw this take up to 2 minutes.  
- Set `-n auto` or `-n 2` for pytests.. there's a few places where tmppath fixtures will be needed, but this cuts CI time down significantly. 
- Bump setup-uv and uv-version to latest, and enable uv cache. 
