### PR TITLE
Populate the HTTPException body

### DIFF
--- a/src/common/exceptions.cpp
+++ b/src/common/exceptions.cpp
@@ -248,7 +248,7 @@ void PyThrowException(ErrorData &error, PyObject *http_exception) {
 		for (auto &entry : error.ExtraInfo()) {
 			if (entry.first == "status_code") {
 				e.attr("status_code") = std::stoi(entry.second);
-			} else if (entry.first == "response_body") {
+			} else if (entry.first == "response_body" || entry.first == "body") {
 				e.attr("body") = entry.second;
 			} else if (entry.first == "reason") {
 				e.attr("reason") = entry.second;

--- a/tests/extensions/test_httpfs.py
+++ b/tests/extensions/test_httpfs.py
@@ -69,6 +69,7 @@ class TestHTTPFS:
         value = exc.value
         assert value.status_code != 200
         assert isinstance(value.body, str)
+        assert value.body != ""
         assert "Content-Length" in value.headers
 
     def test_fsspec_priority(self, require):

--- a/tests/extensions/test_httpfs.py
+++ b/tests/extensions/test_httpfs.py
@@ -68,7 +68,7 @@ class TestHTTPFS:
 
         value = exc.value
         assert value.status_code != 200
-        assert value.body == ""
+        assert isinstance(value.body, str)
         assert "Content-Length" in value.headers
 
     def test_fsspec_priority(self, require):


### PR DESCRIPTION
I was trying to debug 404s and wasn't able to see the HTTP response body — it's always an empty string. I found the relevant code, then had Copilot make the fix. I tried running the test locally, but couldn't figure out how to build with httpfs. Hoping that CI shows it working. I haven't done C++ in 20 years, so open to any suggestions.

Here's Copilot's explanation of the change:

---

`HTTPException.body` could remain empty because Python exception mapping only read `response_body` from DuckDB error extra-info. Some HTTP errors now surface payload under `body`, so the attribute was silently unset.

- **Exception field mapping**
  - Update HTTP exception translation to accept both extra-info keys:
    - legacy: `response_body`
    - current/alternate: `body`
  - This preserves backward compatibility while correctly populating `HTTPException.body` for newer payloads.

- **Test expectation alignment**
  - Adjust HTTPFS exception assertion to validate `body` as a string instead of assuming it is always empty.

```cpp
} else if (entry.first == "response_body" || entry.first == "body") {
    e.attr("body") = entry.second;
}
```